### PR TITLE
Add community tree planting via shared Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Inspired by Lingdong Huang's [\{Shan, Shui\}\*](https://github.com/LingDong-/sha
 2. **Plant** — Community trees and the ITP archive in `names.json` merge into one list (community newest first). Index 0 sits at the screen center; higher indices alternate right, left, further right, further left, with stable seeded gaps. Pan forever — the list loops along the ridge.
 3. **Sign** — APack stamps mark authorship on each tree, visible marks of who grew what.
 4. **Explore** — D3 zoom and pan reveal an endless scroll; new terrain loads as you move.
-5. **Return** — Open **My trees** to see and delete trees you planted (shared browser ID with [tree.bairui.dev](https://tree.bairui.dev/)).
+5. **Return** — Open **My trees** to browse, focus, or delete trees you planted (shared browser ID with [tree.bairui.dev](https://tree.bairui.dev/)). A live count shows how many trees are in the landscape.
 6. **Present** — At ITP Winter Show 2025, [Chloe](https://www.instagram.com/qiyun_chloe/) and I printed 60 pages on a [Riso](https://us.riso.com/) printer and tiled them on the wall, making the digital forest tangible.
 
 ## Why it exists
@@ -103,7 +103,7 @@ cp .env.example .env.local   # optional: enable planting via Supabase
 pnpm dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173). Scroll and zoom to explore. Without `.env.local`, the landscape loads; planting shows a friendly “not connected” message.
+Open [http://localhost:5173](http://localhost:5173). Scroll and zoom to explore. Without `.env.local`, the landscape loads; planting shows a friendly “not connected” message. The **?** button in modals walks through how a name becomes a tree.
 
 ```bash
 pnpm build     # production build
@@ -126,7 +126,9 @@ infinite-landscape/
 ├── src/
 │   ├── render.js   # Mountains, trees, zoom, lazy loading
 │   ├── tree.js     # Name → tree SVG (Charming.js)
-│   ├── ui.js       # Plant / My trees modals
+│   ├── ui.js           # Plant / My trees modals
+│   ├── howItWorks.js   # Step-by-step name → tree guide
+│   ├── animateTree.js  # Grow animation when planting
 │   ├── gradient.js # Radial gradient helpers
 │   ├── noise.js    # Perlin noise for terrain
 │   ├── theme.js    # Sky and mountain palette

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Inspired by Lingdong Huang's [\{Shan, Shui\}\*](https://github.com/LingDong-/sha
 ## What it does
 
 1. **Generate** — Midpoint-displacement mountains unfold in two depth layers with radial gradients in blue, green, and gold.
-2. **Plant** — Type a name and add your tree to the ridgeline; community trees appear nearest x = 0, newest first. The ITP archive in `names.json` fills the rest of the landscape.
+2. **Plant** — Community trees and the ITP archive in `names.json` merge into one list (community newest first). Index 0 sits at the screen center; higher indices alternate right, left, further right, further left, with stable seeded gaps. Pan forever — the list loops along the ridge.
 3. **Sign** — APack stamps mark authorship on each tree, visible marks of who grew what.
 4. **Explore** — D3 zoom and pan reveal an endless scroll; new terrain loads as you move.
 5. **Return** — Open **My trees** to see and delete trees you planted (shared browser ID with [tree.bairui.dev](https://tree.bairui.dev/)).
@@ -51,7 +51,7 @@ The landscape itself evolved in stages:
 ## How it works
 
 ```
-names.json (ITP Spring Show participants)
+community trees + names.json (merged ranks)
       │
       ▼
 ┌─────────────────────────────────────┐
@@ -61,7 +61,7 @@ names.json (ITP Spring Show participants)
       │
       ▼
 ┌─────────────────────────────────────┐
-│  generateTrees()                    │  place each name on the ridgeline
+│  placeMergedTrees()                 │  center-out slots, seeded gaps, infinite loop
 │  tree.js → Charming.js SVG          │  APack stamp per tree
 └─────────────────────────────────────┘
       │

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Inspired by Lingdong Huang's [\{Shan, Shui\}\*](https://github.com/LingDong-/sha
 ## What it does
 
 1. **Generate** — Midpoint-displacement mountains unfold in two depth layers with radial gradients in blue, green, and gold.
-2. **Plant** — Every tree in `names.json` is placed along the ridgeline, drawn by [Charming.js](https://charmingjs.org/) from the same name-to-tree algorithm as [Name2Tree](https://tree.bairui.dev/).
+2. **Plant** — Type a name and add your tree to the ridgeline; community trees appear nearest x = 0, newest first. The ITP archive in `names.json` fills the rest of the landscape.
 3. **Sign** — APack stamps mark authorship on each tree, visible marks of who grew what.
 4. **Explore** — D3 zoom and pan reveal an endless scroll; new terrain loads as you move.
-5. **Present** — At ITP Winter Show 2025, [Chloe](https://www.instagram.com/qiyun_chloe/) and I printed 60 pages on a [Riso](https://us.riso.com/) printer and tiled them on the wall, making the digital forest tangible.
+5. **Return** — Open **My trees** to see and delete trees you planted (shared browser ID with [tree.bairui.dev](https://tree.bairui.dev/)).
+6. **Present** — At ITP Winter Show 2025, [Chloe](https://www.instagram.com/qiyun_chloe/) and I printed 60 pages on a [Riso](https://us.riso.com/) printer and tiled them on the wall, making the digital forest tangible.
 
 ## Why it exists
 
@@ -83,9 +84,12 @@ names.json (ITP Spring Show participants)
 |-------|-------|
 | Rendering | [D3.js](https://d3js.org/) — zoom, paths, data join |
 | Trees | [Charming.js](https://charmingjs.org/), [apackjs](https://apack.bairui.dev/) |
+| Community | [Supabase](https://supabase.com/) — Postgres `landscape_trees` table, `@supabase/supabase-js`, Row Level Security |
+| Validation | `bad-words` profanity filter, length and URL/email checks (client-side) |
 | Noise | Custom Perlin (`noise.js`), `gl-matrix` |
 | Gradients | SVG `radialGradient` (`gradient.js`) |
 | Build | Vite |
+| Deploy | Vercel |
 
 ## Getting started
 
@@ -95,10 +99,11 @@ names.json (ITP Spring Show participants)
 git clone https://github.com/pearmini/infinite-landscape.git
 cd infinite-landscape
 pnpm install
+cp .env.example .env.local   # optional: enable planting via Supabase
 pnpm dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173). Scroll and zoom to explore.
+Open [http://localhost:5173](http://localhost:5173). Scroll and zoom to explore. Without `.env.local`, the landscape loads; planting shows a friendly “not connected” message.
 
 ```bash
 pnpm build     # production build
@@ -107,6 +112,13 @@ pnpm preview   # preview production build
 
 Append `?show=true` for fullscreen kiosk mode (hides footer links, adds a fullscreen button).
 
+### Supabase setup (community planting)
+
+Uses the same Supabase project as [tree.bairui.dev](https://tree.bairui.dev/) (`bairui-studio`). Browser IDs are shared via `name2tree_browser_id` in `localStorage`, so trees you plant here and in the forest app belong to the same visitor identity.
+
+1. Run [`supabase/landscape_trees.sql`](supabase/landscape_trees.sql) in the Supabase SQL Editor.
+2. Set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in `.env.local` and on Vercel.
+
 ## Project structure
 
 ```
@@ -114,11 +126,19 @@ infinite-landscape/
 ├── src/
 │   ├── render.js   # Mountains, trees, zoom, lazy loading
 │   ├── tree.js     # Name → tree SVG (Charming.js)
+│   ├── ui.js       # Plant / My trees modals
 │   ├── gradient.js # Radial gradient helpers
 │   ├── noise.js    # Perlin noise for terrain
 │   ├── theme.js    # Sky and mountain palette
 │   ├── names.json  # ITP Spring Show participant names
-│   └── main.js     # Mount, resize, kiosk mode
+│   ├── main.js     # Mount, resize, kiosk mode
+│   └── lib/
+│       ├── browserId.js        # Shared visitor ID with Name2Tree
+│       ├── supabase.js         # Client + browser ID header
+│       ├── validateName.js     # Profanity and input checks
+│       └── landscapeTreesApi.js
+├── supabase/
+│   └── landscape_trees.sql     # Schema + RLS
 ├── img/            # Screenshots and documentation images
 └── index.html
 ```

--- a/index.html
+++ b/index.html
@@ -606,8 +606,8 @@
     <div class="content">
       <h1 class="title">{Mountains, Trees, Names}*</h1>
       <p class="description">
-        Pan and zoom a procedurally generated infinite landscape. Every name becomes a tree —
-        <a href="https://tree.bairui.dev" target="_blank">plant yours</a>.
+        Pan and zoom a procedurally generated infinite landscape. Every name becomes a
+        <a href="https://tree.bairui.dev" target="_blank" rel="noopener noreferrer">tree</a>.
       </p>
     </div>
     <div id="container"></div>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,14 @@
       opacity: 0.85;
     }
 
+    .tree-count {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      margin: 10px 0 0;
+      opacity: 0.7;
+      letter-spacing: 0.02em;
+    }
+
     .content a {
       color: inherit;
       text-decoration-thickness: 1px;
@@ -256,18 +264,28 @@
       justify-content: flex-end;
     }
 
+    .modal-dialog-my-trees {
+      width: min(720px, 100%);
+    }
+
     .my-trees-body {
       padding-top: 8px;
+      overflow-x: auto;
+      overflow-y: hidden;
+      -webkit-overflow-scrolling: touch;
     }
 
     .my-trees-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-      gap: 12px;
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 16px;
+      padding-bottom: 4px;
     }
 
     .my-tree-cell {
       position: relative;
+      flex: 0 0 280px;
+      width: 280px;
       border: 1.5px solid var(--ink);
       border-radius: 4px;
       overflow: hidden;
@@ -277,13 +295,23 @@
     .my-tree-thumb {
       width: 100%;
       aspect-ratio: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+
+    .my-tree-thumb svg {
+      display: block;
+      width: 100%;
+      height: 100%;
     }
 
     .my-tree-label {
       font-family: var(--font-mono);
-      font-size: 11px;
+      font-size: 13px;
       margin: 0;
-      padding: 6px 8px;
+      padding: 8px 10px;
       background: var(--panel);
       border-top: 1px solid rgba(26, 26, 26, 0.15);
       white-space: nowrap;
@@ -291,57 +319,43 @@
       text-overflow: ellipsis;
     }
 
-    .my-tree-delete {
+    .my-tree-actions {
       position: absolute;
-      top: 6px;
-      right: 6px;
-      width: 16px;
-      height: 16px;
-      padding: 0;
-      border: none;
-      background: transparent;
-      cursor: pointer;
+      top: 8px;
+      right: 8px;
+      display: flex;
+      gap: 6px;
+      opacity: 0;
       pointer-events: none;
-      transition: width 0.15s ease, height 0.15s ease, background 0.15s ease;
+      transition: opacity 0.15s ease;
     }
 
-    .my-tree-dot {
-      display: block;
-      font-family: var(--font-mono);
-      font-size: 16px;
-      font-weight: bold;
-      line-height: 1;
-      color: var(--ink);
-    }
-
-    .my-tree-trash {
-      display: none;
-      align-items: center;
-      justify-content: center;
-      color: var(--ink);
-    }
-
-    .my-tree-cell:hover .my-tree-delete {
-      width: 26px;
-      height: 26px;
-      border: 1.5px solid var(--ink);
+    .my-tree-action {
+      width: 28px;
+      height: 28px;
+      padding: 0;
+      border: 1.5px solid transparent;
       border-radius: 4px;
-      background: var(--panel);
-      pointer-events: auto;
+      background: transparent;
+      color: var(--ink);
+      cursor: pointer;
       display: flex;
       align-items: center;
       justify-content: center;
+      transition: background 0.15s ease, border-color 0.15s ease;
     }
 
-    .my-tree-cell:hover .my-tree-dot {
-      display: none;
+    .my-tree-cell:hover .my-tree-actions {
+      opacity: 1;
+      pointer-events: auto;
     }
 
-    .my-tree-cell:hover .my-tree-trash {
-      display: flex;
+    .my-tree-cell:hover .my-tree-action {
+      border-color: var(--ink);
+      background: var(--panel);
     }
 
-    .my-tree-delete:active {
+    .my-tree-action:active {
       background: var(--ink);
       color: var(--panel);
     }

--- a/index.html
+++ b/index.html
@@ -177,6 +177,11 @@
       box-sizing: border-box;
     }
 
+    .modal-group {
+      position: relative;
+      flex-shrink: 0;
+    }
+
     .modal-dialog {
       width: min(480px, 100%);
       max-height: 90vh;
@@ -185,12 +190,28 @@
       border: 1.5px solid var(--ink);
       border-radius: 8px;
       box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+      flex-shrink: 0;
+      scrollbar-gutter: stable;
+    }
+
+    .modal-help-dialog {
+      width: 360px;
+      overflow-x: hidden;
+      overflow-y: auto;
+      scrollbar-gutter: stable;
+    }
+
+    .modal-group-with-help .modal-help-dialog {
+      position: absolute;
+      left: calc(100% + 2px);
+      top: 0;
     }
 
     .modal-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 12px;
       padding: 16px 18px 0;
     }
 
@@ -201,15 +222,203 @@
       margin: 0;
     }
 
+    .modal-header-actions {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+
+    .modal-help,
     .modal-close {
       font-family: var(--font-mono);
-      font-size: 22px;
       line-height: 1;
       border: none;
       background: transparent;
       cursor: pointer;
       color: var(--ink);
       padding: 0 4px;
+    }
+
+    .modal-help {
+      font-size: 17px;
+      font-weight: 600;
+      width: 24px;
+      height: 24px;
+      border-radius: 999px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .modal-help:hover,
+    .modal-help[aria-pressed="true"] {
+      background: var(--paper);
+    }
+
+    .modal-close {
+      font-size: 22px;
+    }
+
+    .help-body {
+      padding-top: 10px;
+    }
+
+    .help-step-title {
+      font-family: var(--font-serif);
+      font-size: 14px;
+      line-height: 1.45;
+      margin: 0 0 14px;
+      min-height: 4.35em;
+    }
+
+    .help-step-title a {
+      color: inherit;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 2px;
+    }
+
+    .help-visual {
+      height: 300px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      background: var(--paper);
+      border: 1px solid rgba(26, 26, 26, 0.15);
+      border-radius: 4px;
+      padding: 14px;
+      margin-bottom: 14px;
+      overflow: hidden;
+      box-sizing: border-box;
+    }
+
+    .help-visual-content {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      min-height: 0;
+    }
+
+    .help-ascii {
+      font-family: var(--font-mono);
+      font-size: 14px;
+      line-height: 1.8;
+      width: 100%;
+    }
+
+    .help-ascii p {
+      margin: 0;
+    }
+
+    .help-ascii-result {
+      margin-top: 8px !important;
+      padding-top: 8px;
+      border-top: 1px solid rgba(26, 26, 26, 0.12);
+    }
+
+    .help-char,
+    .help-code {
+      font-weight: 600;
+    }
+
+    .help-arrow {
+      margin: 0 8px;
+      opacity: 0.6;
+    }
+
+    .help-code-block {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      font-weight: 600;
+      margin: 0;
+      letter-spacing: 0.04em;
+      height: 1.25em;
+      line-height: 1.25;
+      flex-shrink: 0;
+      width: 100%;
+      text-align: center;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .help-code-block:empty,
+    .help-code-block[aria-hidden="true"] {
+      visibility: hidden;
+    }
+
+    .help-tree-preview {
+      width: 220px;
+      height: 220px;
+      flex-shrink: 0;
+    }
+
+    .help-nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .help-nav-btn {
+      font-family: var(--font-mono);
+      font-size: 16px;
+      width: 36px;
+      height: 36px;
+      border: 1.5px solid var(--ink);
+      border-radius: 999px;
+      background: var(--panel);
+      color: var(--ink);
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    .help-nav-btn:disabled {
+      opacity: 0.35;
+      cursor: default;
+    }
+
+    .help-nav-btn:not(:disabled):hover {
+      background: var(--paper);
+    }
+
+    .help-dots {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      flex: 1;
+    }
+
+    .help-dot {
+      width: 8px;
+      height: 8px;
+      padding: 0;
+      border: 1.5px solid var(--ink);
+      border-radius: 999px;
+      background: transparent;
+      cursor: pointer;
+    }
+
+    .help-dot-active {
+      background: var(--ink);
+    }
+
+    @media (max-width: 860px) {
+      .modal-group-with-help {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 2px;
+      }
+
+      .modal-group-with-help .modal-help-dialog {
+        position: static;
+        width: 100%;
+      }
     }
 
     .modal-body {

--- a/index.html
+++ b/index.html
@@ -127,6 +127,15 @@
       cursor: wait;
     }
 
+    body.interaction-blocked .github-link {
+      pointer-events: none;
+      opacity: 0.55;
+    }
+
+    body.interaction-blocked #container {
+      pointer-events: none;
+    }
+
     .toolbar-btn-primary {
       background: var(--ink);
       color: var(--panel);

--- a/index.html
+++ b/index.html
@@ -489,8 +489,12 @@
       justify-content: flex-end;
     }
 
+    .modal-group:has(.modal-dialog-my-trees) {
+      width: min(960px, calc(100vw - 40px));
+    }
+
     .modal-dialog-my-trees {
-      width: min(720px, 100%);
+      width: 100%;
     }
 
     .my-trees-body {

--- a/index.html
+++ b/index.html
@@ -261,15 +261,14 @@
     }
 
     .help-body {
-      padding-top: 10px;
+      padding-top: 4px;
     }
 
     .help-step-title {
       font-family: var(--font-serif);
       font-size: 14px;
       line-height: 1.45;
-      margin: 0 0 14px;
-      min-height: 4.35em;
+      margin: 0 0 8px;
     }
 
     .help-step-title a {

--- a/index.html
+++ b/index.html
@@ -4,12 +4,28 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{Mountains, Trees, Names}*</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <style>
+    :root {
+      --font-serif: "Newsreader", Georgia, serif;
+      --font-mono: "IBM Plex Mono", monospace;
+      --ink: #1a1a1a;
+      --paper: #f6d87b;
+      --panel: #fefaf1;
+      --error: #a33;
+    }
+
     body {
       margin: 0;
       padding: 0;
-      font-family: Arial, sans-serif;
+      font-family: var(--font-serif);
+      color: var(--ink);
       overflow: hidden;
     }
 
@@ -26,35 +42,320 @@
       align-items: flex-end;
       position: absolute;
       bottom: 20px;
-      right: 10px;
+      right: 16px;
       z-index: 100;
+      max-width: 320px;
+      text-align: right;
     }
 
     .title {
-      font-size: 16px;
-      margin: 0 0 10px 0;
+      font-family: var(--font-serif);
+      font-size: 17px;
+      font-weight: 500;
+      margin: 0 0 8px 0;
+      letter-spacing: 0.01em;
     }
 
     .description {
-      font-size: 12px;
+      font-family: var(--font-serif);
+      font-size: 13px;
+      line-height: 1.45;
       margin: 0;
+      opacity: 0.85;
     }
 
     .content a {
       color: inherit;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 2px;
+    }
+
+    .github-link {
+      position: fixed;
+      top: 16px;
+      right: 16px;
+      z-index: 200;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      border-radius: 999px;
+      border: 1.5px solid var(--ink);
+      background: rgba(254, 250, 241, 0.92);
+      color: var(--ink);
+      backdrop-filter: blur(4px);
+      transition: background 0.15s ease, color 0.15s ease;
+    }
+
+    .github-link:hover {
+      background: var(--panel);
+    }
+
+    .github-link:active {
+      background: var(--ink);
+      color: var(--panel);
+    }
+
+    .github-link svg {
+      width: 18px;
+      height: 18px;
+      fill: currentColor;
+    }
+
+    .toolbar {
+      position: fixed;
+      top: 16px;
+      left: 16px;
+      z-index: 200;
+      display: flex;
+      gap: 8px;
+    }
+
+    .toolbar-btn {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      font-weight: 500;
+      padding: 8px 14px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    }
+
+    .toolbar-btn:disabled {
+      opacity: 0.6;
+      cursor: wait;
+    }
+
+    .toolbar-btn-primary {
+      background: var(--ink);
+      color: var(--panel);
+      border: 1.5px solid var(--ink);
+    }
+
+    .toolbar-btn-primary:hover:not(:disabled) {
+      background: #333;
+    }
+
+    .toolbar-btn-secondary {
+      background: rgba(254, 250, 241, 0.92);
+      color: var(--ink);
+      border: 1.5px solid var(--ink);
+      backdrop-filter: blur(4px);
+    }
+
+    .toolbar-btn-secondary:hover:not(:disabled) {
+      background: var(--panel);
+    }
+
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+      background: rgba(0, 0, 0, 0.45);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+      box-sizing: border-box;
+    }
+
+    .modal-dialog {
+      width: min(480px, 100%);
+      max-height: 90vh;
+      overflow: auto;
+      background: var(--panel);
+      border: 1.5px solid var(--ink);
+      border-radius: 8px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+    }
+
+    .modal-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 18px 0;
+    }
+
+    .modal-title {
+      font-family: var(--font-mono);
+      font-size: 15px;
+      font-weight: 600;
+      margin: 0;
+    }
+
+    .modal-close {
+      font-family: var(--font-mono);
+      font-size: 22px;
+      line-height: 1;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      color: var(--ink);
+      padding: 0 4px;
+    }
+
+    .modal-body {
+      padding: 16px 18px 20px;
+    }
+
+    .modal-preview {
+      width: 100%;
+      aspect-ratio: 1;
+      margin-bottom: 14px;
+      background: var(--paper);
+      border: 1px solid rgba(26, 26, 26, 0.15);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .modal-input {
+      width: 100%;
+      box-sizing: border-box;
+      font-family: var(--font-mono);
+      font-size: 14px;
+      padding: 10px 12px;
+      border: 1.5px solid var(--ink);
+      border-radius: 4px;
+      background: #fff;
+      margin-bottom: 10px;
+    }
+
+    .modal-input:focus {
+      outline: 2px solid var(--paper);
+      outline-offset: 1px;
+    }
+
+    .modal-error {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--error);
+      margin: 0 0 12px;
+    }
+
+    .modal-message {
+      font-family: var(--font-serif);
+      font-size: 14px;
+      line-height: 1.5;
+      margin: 0;
+      padding: 0 18px 20px;
+      color: #333;
+    }
+
+    .modal-actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .my-trees-body {
+      padding-top: 8px;
+    }
+
+    .my-trees-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 12px;
+    }
+
+    .my-tree-cell {
+      position: relative;
+      border: 1.5px solid var(--ink);
+      border-radius: 4px;
+      overflow: hidden;
+      background: var(--paper);
+    }
+
+    .my-tree-thumb {
+      width: 100%;
+      aspect-ratio: 1;
+    }
+
+    .my-tree-label {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      margin: 0;
+      padding: 6px 8px;
+      background: var(--panel);
+      border-top: 1px solid rgba(26, 26, 26, 0.15);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .my-tree-delete {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      width: 16px;
+      height: 16px;
+      padding: 0;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      pointer-events: none;
+      transition: width 0.15s ease, height 0.15s ease, background 0.15s ease;
+    }
+
+    .my-tree-dot {
+      display: block;
+      font-family: var(--font-mono);
+      font-size: 16px;
+      font-weight: bold;
+      line-height: 1;
+      color: var(--ink);
+    }
+
+    .my-tree-trash {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      color: var(--ink);
+    }
+
+    .my-tree-cell:hover .my-tree-delete {
+      width: 26px;
+      height: 26px;
+      border: 1.5px solid var(--ink);
+      border-radius: 4px;
+      background: var(--panel);
+      pointer-events: auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .my-tree-cell:hover .my-tree-dot {
+      display: none;
+    }
+
+    .my-tree-cell:hover .my-tree-trash {
+      display: flex;
+    }
+
+    .my-tree-delete:active {
+      background: var(--ink);
+      color: var(--panel);
     }
   </style>
   <body>
+    <a
+      class="github-link"
+      href="https://github.com/pearmini/infinite-landscape"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="GitHub repository"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"
+        />
+      </svg>
+    </a>
     <div class="content">
-      <h1 class="title">
-        <a href="https://github.com/pearmini/infinite-landscape" target="_blank">{Mountains, Trees, Names}*</a>
-      </h1>
+      <h1 class="title">{Mountains, Trees, Names}*</h1>
       <p class="description">
-        A Procedurally Generated Infinite Landscape by
-        <a href="https://tree.bairui.dev" target="_blank">Find the Tree in Your Name</a> Participants in
-        <a href="https://itp.nyu.edu/shows/spring2025/projects/#11830-find-the-tree-in-your-name" target="_blank"
-          >ITP Spring 2025</a
-        >.
+        Pan and zoom a procedurally generated infinite landscape. Every name becomes a tree —
+        <a href="https://tree.bairui.dev" target="_blank">plant yours</a>.
       </p>
     </div>
     <div id="container"></div>

--- a/index.html
+++ b/index.html
@@ -170,41 +170,50 @@
       inset: 0;
       z-index: 1000;
       background: rgba(0, 0, 0, 0.45);
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      display: grid;
+      place-items: center;
       padding: 20px;
       box-sizing: border-box;
     }
 
     .modal-group {
       position: relative;
-      flex-shrink: 0;
+      width: min(480px, calc(100vw - 40px));
+      max-width: calc(100vw - 40px);
+    }
+
+    .modal-group-with-help {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      gap: 12px;
+      width: max-content;
+      max-width: calc(100vw - 40px);
     }
 
     .modal-dialog {
-      width: min(480px, 100%);
+      width: 100%;
       max-height: 90vh;
       overflow: auto;
       background: var(--panel);
       border: 1.5px solid var(--ink);
       border-radius: 8px;
       box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
-      flex-shrink: 0;
       scrollbar-gutter: stable;
+    }
+
+    .modal-group-with-help .modal-dialog {
+      width: 480px;
+      flex: 0 0 480px;
     }
 
     .modal-help-dialog {
       width: 360px;
+      max-height: 90vh;
       overflow-x: hidden;
       overflow-y: auto;
       scrollbar-gutter: stable;
-    }
-
-    .modal-group-with-help .modal-help-dialog {
-      position: absolute;
-      left: calc(100% + 2px);
-      top: 0;
+      flex: 0 0 auto;
     }
 
     .modal-header {
@@ -278,7 +287,7 @@
     }
 
     .help-visual {
-      height: 300px;
+      height: 400px;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -350,8 +359,8 @@
     }
 
     .help-tree-preview {
-      width: 220px;
-      height: 220px;
+      width: 280px;
+      height: 280px;
       flex-shrink: 0;
     }
 
@@ -406,16 +415,15 @@
       background: var(--ink);
     }
 
-    @media (max-width: 860px) {
+    @media (max-width: 900px) {
       .modal-group-with-help {
-        display: flex;
         flex-direction: column;
         align-items: stretch;
-        gap: 2px;
+        gap: 12px;
       }
 
+      .modal-group-with-help .modal-dialog,
       .modal-group-with-help .modal-help-dialog {
-        position: static;
         width: 100%;
       }
     }
@@ -449,6 +457,15 @@
     .modal-input:focus {
       outline: 2px solid var(--paper);
       outline-offset: 1px;
+    }
+
+    .modal-privacy {
+      font-family: var(--font-serif);
+      font-size: 12px;
+      line-height: 1.45;
+      color: #444;
+      opacity: 0.85;
+      margin: 0 0 12px;
     }
 
     .modal-error {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "vite": "^5.4.21"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.49.0",
     "apackjs": "0.0.1",
+    "bad-words": "^4.0.0",
     "charmingjs": "0.0.17",
     "d3": "^7.9.0",
     "gl-matrix": "^3.4.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@supabase/supabase-js':
+        specifier: ^2.49.0
+        version: 2.107.0
       apackjs:
         specifier: 0.0.1
         version: 0.0.1
+      bad-words:
+        specifier: ^4.0.0
+        version: 4.0.0
       charmingjs:
         specifier: 0.0.17
         version: 0.0.17
@@ -275,11 +281,45 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@supabase/auth-js@2.107.0':
+    resolution: {integrity: sha512-XA7x+WIeIvuC3GTZ2ey67QcBbGw4n+o5B7M+dMm9KT1lL3wX1B52DfEWW00WuPt/LnniJLLIn1WIm9YPtuxzKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.107.0':
+    resolution: {integrity: sha512-iMtRUmEj1KOgQd/a3MR4hnBlPnZc62DW8+z8aPpnzbxWkexEZUVL2fSgvvp15gqFg1V55e2yMGqgK+yhSQxp5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+
+  '@supabase/postgrest-js@2.107.0':
+    resolution: {integrity: sha512-7ARs47/tyIjX7T0Ive20d4NY8zQYXsP5/P07jJWxffSIM2gpnSnGRnL/Fe15GPbdjsW2sTYeckHcyaoKbM6yWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.107.0':
+    resolution: {integrity: sha512-cF2KYdR3JIn9YlWGeluY9S0G+otqTdL6hB8GzpatlEIY6fZudCcyFo6Dc3+X9tjeb+x9XcIyNAk9qhNAknjH1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.107.0':
+    resolution: {integrity: sha512-/X8OOVwKBn8aVKuHAGOz2yLA0d2OauqhVuy4mNtN+o7wttHOgx1/j+pqOzlsjmhOHrYykF6AJNZhs3gKZzcMUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.107.0':
+    resolution: {integrity: sha512-ChKzdlWVweMUUhr0U79JhMmgm1haS/C5JquaiCDr70JaGARRtjjoY9rkIheXWybXxTSNzRiQs3Sk8IAg1HS3ZA==}
+    engines: {node: '>=20.0.0'}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   apackjs@0.0.1:
     resolution: {integrity: sha512-Z1k4kMS1KnoOGnkaQ0i/BB660tNDIoT6hbRQziFIH5n4s4b+vUYaq21wZQ0DMpwE37NybYy8LtdxUBgOBHuD7w==}
+
+  bad-words@4.0.0:
+    resolution: {integrity: sha512-fLjG/I0N3I7xhurqGnGitSRD10UeEE63a7hyXtutQDpxo4+Eal+i7veWeZxZJPNtsl6X1mUIoWPwt8gQ7NMQUw==}
+    engines: {node: '>=8.0.0'}
+
+  badwords-list@2.0.1-4:
+    resolution: {integrity: sha512-FxfZUp7B9yCnesNtFQS9v6PvZdxTYa14Q60JR6vhjdQdWI4naTjJIyx22JzoER8ooeT8SAAKoHLjKfCV7XgYUQ==}
 
   charmingjs-vector@0.0.3:
     resolution: {integrity: sha512-7nvY6XOgjErbj5M0hJzNCdjkFCF5JfWNp6wFyqVYPAGrK2hd78hr5GL8bHAUsZomH+eE9Co2AgBw24cwwQu+bg==}
@@ -434,6 +474,10 @@ packages:
   gl-matrix@3.4.4:
     resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -471,6 +515,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
@@ -640,6 +687,38 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
 
+  '@supabase/auth-js@2.107.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.107.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.2': {}
+
+  '@supabase/postgrest-js@2.107.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.107.0':
+    dependencies:
+      '@supabase/phoenix': 0.4.2
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.107.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.107.0':
+    dependencies:
+      '@supabase/auth-js': 2.107.0
+      '@supabase/functions-js': 2.107.0
+      '@supabase/postgrest-js': 2.107.0
+      '@supabase/realtime-js': 2.107.0
+      '@supabase/storage-js': 2.107.0
+
   '@types/estree@1.0.8': {}
 
   apackjs@0.0.1:
@@ -650,6 +729,12 @@ snapshots:
       d3-random: 3.0.1
       d3-scale: 4.0.2
       d3-shape: 3.2.0
+
+  bad-words@4.0.0:
+    dependencies:
+      badwords-list: 2.0.1-4
+
+  badwords-list@2.0.1-4: {}
 
   charmingjs-vector@0.0.3: {}
 
@@ -847,6 +932,8 @@ snapshots:
 
   gl-matrix@3.4.4: {}
 
+  iceberg-js@0.8.1: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -898,6 +985,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   source-map-js@1.2.1: {}
+
+  tslib@2.8.1: {}
 
   vite@5.4.21:
     dependencies:

--- a/src/animateTree.js
+++ b/src/animateTree.js
@@ -1,0 +1,120 @@
+import * as d3 from "d3";
+
+const BRANCH_DURATION = 380;
+const FLOWER_DURATION = 320;
+const NAME_DURATION = 320;
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function prepareTreeForGrow(groupEl) {
+  const svg = groupEl.querySelector("svg");
+  if (!svg) return;
+
+  svg.querySelectorAll('path[data-tree-part="branch"]').forEach((path) => {
+    const len = path.getTotalLength?.() ?? 0;
+    if (len > 0) {
+      path.setAttribute("stroke-dasharray", `0 ${len}`);
+      path.setAttribute("fill", "none");
+    }
+  });
+
+  svg.querySelectorAll('path[data-tree-part="flower"]').forEach((path) => {
+    path.setAttribute("opacity", "0");
+  });
+
+  svg.querySelectorAll('g[data-tree-part="flower"]').forEach((group) => {
+    group.setAttribute("opacity", "0");
+  });
+
+  const nameGroup = svg.querySelector('[data-tree-part="name"]');
+  if (nameGroup) {
+    nameGroup.setAttribute("opacity", "0");
+    nameGroup.querySelectorAll("path, text, rect, line, circle").forEach((el) => {
+      el.setAttribute("opacity", "0");
+    });
+  }
+}
+
+function animateBranchPaths(paths) {
+  if (paths.length === 0) return Promise.resolve(0);
+
+  const sorted = [...paths].sort(
+    (a, b) => Number(a.dataset.depth ?? 0) - Number(b.dataset.depth ?? 0),
+  );
+  const maxDepth = Math.max(...sorted.map((path) => Number(path.dataset.depth ?? 1)));
+
+  const selection = d3.selectAll(sorted);
+  selection.each(function () {
+    const len = this.getTotalLength?.() ?? 0;
+    if (len > 0) {
+      d3.select(this).attr("stroke-dasharray", `0 ${len}`).attr("fill", "none");
+    }
+  });
+
+  return new Promise((resolve) => {
+    selection
+      .transition()
+      .delay((d, i, nodes) => {
+        const depth = Number(nodes[i].dataset.depth ?? 1);
+        return (depth - 1) * BRANCH_DURATION;
+      })
+      .duration(BRANCH_DURATION)
+      .attr("stroke-dasharray", function () {
+        const len = this.getTotalLength?.() ?? 0;
+        return `${len} 0`;
+      })
+      .attrTween("stroke-linecap", () => (t) => (t === 1 ? "round" : ""));
+
+    const totalMs = maxDepth * BRANCH_DURATION + 80;
+    setTimeout(resolve, totalMs);
+  });
+}
+
+function fadeInElements(elements, duration, stagger = 50) {
+  if (elements.length === 0) return Promise.resolve(0);
+
+  const selection = d3.selectAll(elements);
+  selection.attr("opacity", 0);
+
+  elements.forEach((el) => {
+    const parent = el.closest('g[data-tree-part="flower"]');
+    if (parent) d3.select(parent).attr("opacity", 1);
+  });
+
+  return new Promise((resolve) => {
+    selection
+      .transition()
+      .delay((_, i) => i * stagger)
+      .duration(duration)
+      .attr("opacity", 1);
+
+    const totalMs = (elements.length - 1) * stagger + duration + 40;
+    setTimeout(resolve, totalMs);
+  });
+}
+
+export async function animateTreeGrow(groupEl) {
+  const svg = groupEl.querySelector("svg");
+  if (!svg) return;
+
+  const branchPaths = [...svg.querySelectorAll('path[data-tree-part="branch"]')];
+  const flowerPaths = [...svg.querySelectorAll('path[data-tree-part="flower"]')];
+  const nameGroup = svg.querySelector('[data-tree-part="name"]');
+  const nameElements = nameGroup
+    ? [...nameGroup.querySelectorAll("path, text, rect, line, circle")]
+    : [];
+
+  const flowerGroups = [...svg.querySelectorAll('g[data-tree-part="flower"]')];
+
+  const branchMs = await animateBranchPaths(branchPaths);
+  await wait(Math.max(0, branchMs * 0.1));
+
+  flowerGroups.forEach((group) => group.setAttribute("opacity", "1"));
+  const flowerMs = await fadeInElements(flowerPaths, FLOWER_DURATION, 60);
+  await wait(Math.max(0, flowerMs * 0.1));
+
+  if (nameGroup) nameGroup.setAttribute("opacity", "1");
+  await fadeInElements(nameElements, NAME_DURATION, 40);
+}

--- a/src/howItWorks.js
+++ b/src/howItWorks.js
@@ -1,0 +1,230 @@
+import {tree} from "./tree.js";
+
+const EXAMPLE = "AB";
+const EDGE_CASE_EXAMPLE = "ego";
+const EDGE_CASE_CODE = "101103111";
+
+const TREE_PREVIEW_OPTIONS = {
+  grid: false,
+  padding: 0,
+  line: false,
+  end: false,
+  width: 480,
+  height: 480,
+};
+
+function renderTreeIn(container, name, options = {}) {
+  const preview = document.createElement("div");
+  preview.className = "help-tree-preview";
+  const width = options.width ?? TREE_PREVIEW_OPTIONS.width;
+  const height = options.height ?? width;
+  const node = tree(name, {...TREE_PREVIEW_OPTIONS, ...options, width, height}).render();
+  node.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  node.setAttribute("preserveAspectRatio", "xMidYMid meet");
+  node.style.width = "100%";
+  node.style.height = "100%";
+  node.style.display = "block";
+  preview.appendChild(node);
+  container.appendChild(preview);
+}
+
+function renderHelpVisual(container, {code, renderContent}) {
+  container.innerHTML = "";
+
+  const codeEl = document.createElement("p");
+  codeEl.className = "help-code-block";
+  codeEl.textContent = code ?? "";
+  if (!code) codeEl.setAttribute("aria-hidden", "true");
+
+  const content = document.createElement("div");
+  content.className = "help-visual-content";
+  renderContent(content);
+
+  container.append(codeEl, content);
+}
+
+function asciiLines(sample) {
+  const text = sample.trim() || EXAMPLE;
+  const chars = [...text];
+  const codes = chars.map((char) => char.charCodeAt(0));
+  return {text, chars, codes, joined: codes.join("")};
+}
+
+export const HOW_IT_WORKS_STEPS = [
+  {
+    title: "Convert the input string into ASCII codes.",
+    titleHtml:
+      'Convert the input string into <a href="https://en.wikipedia.org/wiki/ASCII" target="_blank" rel="noopener noreferrer">ASCII codes</a>.',
+    render(container, sample = EXAMPLE) {
+      renderHelpVisual(container, {
+        renderContent(content) {
+          const {text, chars, codes, joined} = asciiLines(sample);
+          const lines = chars
+            .map((char, index) => {
+              const code = codes[index];
+              return `<p><span class="help-char">${char}</span><span class="help-arrow">→</span><span class="help-code">${code}</span></p>`;
+            })
+            .join("");
+          content.innerHTML = `<div class="help-ascii">${lines}<p class="help-ascii-result"><span class="help-char">${text}</span><span class="help-arrow">→</span><span class="help-code">${joined}</span></p></div>`;
+        },
+      });
+    },
+  },
+  {
+    title: "Draw a tree based on the ASCII codes.",
+    render(container, sample = EXAMPLE) {
+      renderHelpVisual(container, {
+        renderContent(content) {
+          renderTreeIn(content, sample.trim() || EXAMPLE, {
+            count: true,
+            stamp: false,
+            number: true,
+            line: true,
+          });
+        },
+      });
+    },
+  },
+  {
+    title: "Merge branches into mathematical rose.",
+    titleHtml:
+      'Merge branches into <a href="https://en.wikipedia.org/wiki/Rose_(mathematics)" target="_blank" rel="noopener noreferrer">mathematical rose</a>.',
+    render(container, sample = EXAMPLE) {
+      const {joined} = asciiLines(sample);
+      renderHelpVisual(container, {
+        code: joined,
+        renderContent(content) {
+          renderTreeIn(content, sample.trim() || EXAMPLE, {number: false, stamp: false});
+        },
+      });
+    },
+  },
+  {
+    title: "Optimize edge cases.",
+    render(container) {
+      renderHelpVisual(container, {
+        code: EDGE_CASE_CODE,
+        renderContent(content) {
+          renderTreeIn(content, EDGE_CASE_EXAMPLE, {number: false, stamp: false});
+        },
+      });
+    },
+  },
+  {
+    title: "Render the signature using APack.",
+    titleHtml:
+      'Render the signature using <a href="https://apack.bairui.dev/" target="_blank" rel="noopener noreferrer">APack</a>.',
+    render(container, sample = EXAMPLE) {
+      const {joined} = asciiLines(sample);
+      renderHelpVisual(container, {
+        code: joined,
+        renderContent(content) {
+          renderTreeIn(content, sample.trim() || EXAMPLE, {number: false, stamp: true});
+        },
+      });
+    },
+  },
+];
+
+export function createHowItWorksPanel({getSample = () => EXAMPLE, onClose}) {
+  let stepIndex = 0;
+
+  const panel = document.createElement("div");
+  panel.className = "modal-dialog modal-help-dialog";
+  panel.addEventListener("click", (event) => event.stopPropagation());
+
+  const header = document.createElement("div");
+  header.className = "modal-header";
+
+  const heading = document.createElement("h2");
+  heading.className = "modal-title";
+  heading.textContent = "How it works";
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "modal-close";
+  closeButton.setAttribute("aria-label", "Close");
+  closeButton.textContent = "×";
+  closeButton.addEventListener("click", onClose);
+
+  header.append(heading, closeButton);
+
+  const body = document.createElement("div");
+  body.className = "modal-body help-body";
+
+  const stepTitle = document.createElement("p");
+  stepTitle.className = "help-step-title";
+
+  const visual = document.createElement("div");
+  visual.className = "help-visual";
+
+  const nav = document.createElement("div");
+  nav.className = "help-nav";
+
+  const prevButton = document.createElement("button");
+  prevButton.type = "button";
+  prevButton.className = "help-nav-btn";
+  prevButton.setAttribute("aria-label", "Previous step");
+  prevButton.textContent = "←";
+
+  const dots = document.createElement("div");
+  dots.className = "help-dots";
+  dots.setAttribute("role", "tablist");
+
+  const dotButtons = HOW_IT_WORKS_STEPS.map((_, index) => {
+    const dot = document.createElement("button");
+    dot.type = "button";
+    dot.className = "help-dot";
+    dot.setAttribute("role", "tab");
+    dot.setAttribute("aria-label", `Step ${index + 1}`);
+    dot.addEventListener("click", () => {
+      stepIndex = index;
+      renderStep();
+    });
+    dots.appendChild(dot);
+    return dot;
+  });
+
+  const nextButton = document.createElement("button");
+  nextButton.type = "button";
+  nextButton.className = "help-nav-btn";
+  nextButton.setAttribute("aria-label", "Next step");
+  nextButton.textContent = "→";
+
+  function renderStep() {
+    const step = HOW_IT_WORKS_STEPS[stepIndex];
+    stepTitle.innerHTML = `${stepIndex + 1}. ${step.titleHtml ?? step.title}`;
+    visual.innerHTML = "";
+    step.render(visual, getSample());
+
+    dotButtons.forEach((dot, index) => {
+      const active = index === stepIndex;
+      dot.classList.toggle("help-dot-active", active);
+      dot.setAttribute("aria-selected", active ? "true" : "false");
+    });
+
+    prevButton.disabled = stepIndex === 0;
+    nextButton.disabled = stepIndex === HOW_IT_WORKS_STEPS.length - 1;
+  }
+
+  prevButton.addEventListener("click", () => {
+    if (stepIndex > 0) {
+      stepIndex -= 1;
+      renderStep();
+    }
+  });
+
+  nextButton.addEventListener("click", () => {
+    if (stepIndex < HOW_IT_WORKS_STEPS.length - 1) {
+      stepIndex += 1;
+      renderStep();
+    }
+  });
+
+  nav.append(prevButton, dots, nextButton);
+  body.append(stepTitle, visual, nav);
+  panel.append(header, body);
+  renderStep();
+
+  return panel;
+}

--- a/src/lib/browserId.js
+++ b/src/lib/browserId.js
@@ -1,0 +1,10 @@
+const STORAGE_KEY = "name2tree_browser_id";
+
+export function getBrowserId() {
+  let id = localStorage.getItem(STORAGE_KEY);
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem(STORAGE_KEY, id);
+  }
+  return id;
+}

--- a/src/lib/landscapeTreesApi.js
+++ b/src/lib/landscapeTreesApi.js
@@ -1,0 +1,53 @@
+import {getBrowserId} from "./browserId.js";
+import {getSupabase, isSupabaseConfigured} from "./supabase.js";
+
+function rowToTree(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    createdAt: row.created_at,
+    browserId: row.browser_id,
+    source: "community",
+  };
+}
+
+export async function fetchLandscapeTrees() {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const {data, error} = await supabase
+    .from("landscape_trees")
+    .select("id, name, browser_id, created_at")
+    .order("created_at", {ascending: false});
+
+  if (error) throw error;
+  return (data ?? []).map(rowToTree);
+}
+
+export async function addLandscapeTree(name) {
+  const supabase = getSupabase();
+  if (!supabase) {
+    throw new Error("Landscape is not connected yet. Please try again later.");
+  }
+
+  const {data, error} = await supabase
+    .from("landscape_trees")
+    .insert({name: name.trim(), browser_id: getBrowserId()})
+    .select("id, name, browser_id, created_at")
+    .single();
+
+  if (error) throw error;
+  return rowToTree(data);
+}
+
+export async function deleteLandscapeTree(id) {
+  const supabase = getSupabase();
+  if (!supabase) {
+    throw new Error("Landscape is not connected yet. Please try again later.");
+  }
+
+  const {error} = await supabase.from("landscape_trees").delete().eq("id", id);
+  if (error) throw error;
+}
+
+export {isSupabaseConfigured};

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,25 @@
+import {createClient} from "@supabase/supabase-js";
+import {getBrowserId} from "./browserId.js";
+
+const url = import.meta.env.VITE_SUPABASE_URL;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export function isSupabaseConfigured() {
+  return Boolean(url && anonKey);
+}
+
+let client = null;
+
+export function getSupabase() {
+  if (!isSupabaseConfigured()) return null;
+  if (!client) {
+    client = createClient(url, anonKey, {
+      global: {
+        headers: {
+          "x-browser-id": getBrowserId(),
+        },
+      },
+    });
+  }
+  return client;
+}

--- a/src/lib/validateName.js
+++ b/src/lib/validateName.js
@@ -1,0 +1,24 @@
+import {Filter} from "bad-words";
+
+const filter = new Filter();
+
+const URL_RE = /https?:\/\/|www\./i;
+const EMAIL_RE = /@.+\./i;
+const MAX_LENGTH = 80;
+
+export function validateName(raw) {
+  const name = raw.trim();
+  if (!name) {
+    return {ok: false, error: "Please enter a name or short text."};
+  }
+  if (name.length > MAX_LENGTH) {
+    return {ok: false, error: `Please keep it under ${MAX_LENGTH} characters.`};
+  }
+  if (URL_RE.test(name) || EMAIL_RE.test(name)) {
+    return {ok: false, error: "Please use a friendly name without links or email."};
+  }
+  if (filter.isProfane(name)) {
+    return {ok: false, error: "Please use friendly words only."};
+  }
+  return {ok: true, name};
+}

--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,7 @@ function createAndRender({panToOrigin = false} = {}) {
   container.appendChild(currentController.node);
 
   if (panToOrigin) {
-    requestAnimationFrame(() => currentController.panToWorldX(0));
+    requestAnimationFrame(() => currentController.panToCenter());
   }
 }
 
@@ -54,15 +54,17 @@ async function bootstrap() {
   await loadUserTrees();
   createAndRender();
 
-  initUI({
+  const {setInteractionBlocked} = initUI({
     getUserTrees: () => userTrees,
     refreshUserTrees,
     onAdd: async (name) => {
       const added = await addLandscapeTree(name);
       userTrees = [added, ...userTrees.filter((tree) => tree.id !== added.id)];
       if (currentController) {
-        currentController.setUserTrees(userTrees);
-        currentController.panToWorldX(0);
+        setInteractionBlocked(true);
+        void currentController.setUserTreesAndGrow(userTrees, added.id).finally(() => {
+          setInteractionBlocked(false);
+        });
       }
     },
     onDelete: async (id) => {

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,8 @@ const showFullscreenButton = urlParams.get("show") === "true";
 
 let currentController = null;
 let userTrees = [];
+let setInteractionBlocked = () => {};
+let updateTreeCounts = () => {};
 let currentSeed = process.env.NODE_ENV === "development" ? 10000 : Date.now();
 
 async function loadUserTrees() {
@@ -47,6 +49,7 @@ async function refreshUserTrees() {
   if (currentController) {
     currentController.setUserTrees(userTrees);
   }
+  updateTreeCounts();
   return userTrees;
 }
 
@@ -54,12 +57,13 @@ async function bootstrap() {
   await loadUserTrees();
   createAndRender();
 
-  const {setInteractionBlocked} = initUI({
+  ({setInteractionBlocked, updateTreeCounts} = initUI({
     getUserTrees: () => userTrees,
     refreshUserTrees,
     onAdd: async (name) => {
       const added = await addLandscapeTree(name);
       userTrees = [added, ...userTrees.filter((tree) => tree.id !== added.id)];
+      updateTreeCounts();
       if (currentController) {
         setInteractionBlocked(true);
         void currentController.setUserTreesAndGrow(userTrees, added.id).finally(() => {
@@ -70,11 +74,21 @@ async function bootstrap() {
     onDelete: async (id) => {
       await deleteLandscapeTree(id);
       userTrees = userTrees.filter((tree) => tree.id !== id);
+      updateTreeCounts();
       if (currentController) {
         currentController.setUserTrees(userTrees);
       }
     },
-  });
+    onFocusTree: async (id) => {
+      if (!currentController) return;
+      setInteractionBlocked(true);
+      try {
+        await currentController.panToTreeAnimated(id);
+      } finally {
+        setInteractionBlocked(false);
+      }
+    },
+  }));
 }
 
 bootstrap();

--- a/src/main.js
+++ b/src/main.js
@@ -1,30 +1,82 @@
 import {render} from "./render.js";
+import {initUI} from "./ui.js";
+import {
+  addLandscapeTree,
+  deleteLandscapeTree,
+  fetchLandscapeTrees,
+} from "./lib/landscapeTreesApi.js";
 
-// Check if URL param 'show' is true
 const urlParams = new URLSearchParams(window.location.search);
 const showFullscreenButton = urlParams.get("show") === "true";
 
-let currentNode = null;
+let currentController = null;
+let userTrees = [];
 let currentSeed = process.env.NODE_ENV === "development" ? 10000 : Date.now();
 
-function createAndRender() {
-  const container = document.querySelector("#container");
-  if (currentNode) {
-    container.removeChild(currentNode);
+async function loadUserTrees() {
+  try {
+    userTrees = await fetchLandscapeTrees();
+  } catch (error) {
+    console.error("Failed to load community trees:", error);
+    userTrees = [];
   }
-
-  currentNode = render({
-    width: window.innerWidth,
-    seed: currentSeed,
-  });
-
-  container.appendChild(currentNode);
+  return userTrees;
 }
 
-// Initial render
-createAndRender();
+function createAndRender({panToOrigin = false} = {}) {
+  const container = document.querySelector("#container");
+  if (currentController?.node) {
+    container.removeChild(currentController.node);
+  }
 
-// Convert links to plain text in show mode
+  currentController = render({
+    width: window.innerWidth,
+    seed: currentSeed,
+    userTrees,
+  });
+
+  container.appendChild(currentController.node);
+
+  if (panToOrigin) {
+    requestAnimationFrame(() => currentController.panToWorldX(0));
+  }
+}
+
+async function refreshUserTrees() {
+  await loadUserTrees();
+  if (currentController) {
+    currentController.setUserTrees(userTrees);
+  }
+  return userTrees;
+}
+
+async function bootstrap() {
+  await loadUserTrees();
+  createAndRender();
+
+  initUI({
+    getUserTrees: () => userTrees,
+    refreshUserTrees,
+    onAdd: async (name) => {
+      const added = await addLandscapeTree(name);
+      userTrees = [added, ...userTrees.filter((tree) => tree.id !== added.id)];
+      if (currentController) {
+        currentController.setUserTrees(userTrees);
+        currentController.panToWorldX(0);
+      }
+    },
+    onDelete: async (id) => {
+      await deleteLandscapeTree(id);
+      userTrees = userTrees.filter((tree) => tree.id !== id);
+      if (currentController) {
+        currentController.setUserTrees(userTrees);
+      }
+    },
+  });
+}
+
+bootstrap();
+
 if (showFullscreenButton) {
   const contentDiv = document.querySelector(".content");
   const links = contentDiv.querySelectorAll("a");
@@ -34,14 +86,13 @@ if (showFullscreenButton) {
   });
 }
 
-// Create fullscreen button if show param is true
 if (showFullscreenButton) {
   const fullscreenButton = document.createElement("button");
   fullscreenButton.textContent = "⛶ Fullscreen";
   fullscreenButton.style.cssText = `
     position: fixed;
-    top: 20px;
-    right: 20px;
+    top: 16px;
+    right: 60px;
     z-index: 1000;
     padding: 10px 20px;
     background: rgba(0, 0, 0, 0.7);
@@ -50,6 +101,7 @@ if (showFullscreenButton) {
     border-radius: 4px;
     cursor: pointer;
     font-size: 14px;
+    font-family: "IBM Plex Mono", monospace;
     transition: background 0.2s;
   `;
   fullscreenButton.addEventListener("mouseenter", () => {
@@ -73,7 +125,6 @@ if (showFullscreenButton) {
 
   document.body.appendChild(fullscreenButton);
 
-  // Function to update button visibility based on fullscreen state
   function updateButtonVisibility() {
     const isFullscreen = !!(
       document.fullscreenElement ||
@@ -84,23 +135,18 @@ if (showFullscreenButton) {
     fullscreenButton.style.display = isFullscreen ? "none" : "block";
   }
 
-  // Listen for fullscreen changes to hide/show button
   document.addEventListener("fullscreenchange", updateButtonVisibility);
   document.addEventListener("webkitfullscreenchange", updateButtonVisibility);
   document.addEventListener("mozfullscreenchange", updateButtonVisibility);
   document.addEventListener("MSFullscreenChange", updateButtonVisibility);
 }
 
-// Handle fullscreen changes and resize
 function handleResize() {
   createAndRender();
 }
 
-// Listen for fullscreen changes
 document.addEventListener("fullscreenchange", handleResize);
 document.addEventListener("webkitfullscreenchange", handleResize);
 document.addEventListener("mozfullscreenchange", handleResize);
 document.addEventListener("MSFullscreenChange", handleResize);
-
-// Listen for window resize
 window.addEventListener("resize", handleResize);

--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,5 @@
 import * as d3 from "d3";
+import {animateTreeGrow, prepareTreeForGrow} from "./animateTree.js";
 import {randomNoise} from "./noise.js";
 import {applyGradient} from "./gradient.js";
 import {tree} from "./tree.js";
@@ -165,16 +166,91 @@ function findYOnMountain(x, mountains) {
   return null;
 }
 
-const TREE_SPACING = 350;
 const TREE_DY = 40;
 const TREE_MIN_Y = 420;
 const TREE_MAX_Y = 640;
+const GAP_MIN = 250;
+const GAP_MAX = 450;
 
 function createTreeScaler() {
   return d3.scaleSqrt().domain([TREE_MIN_Y, TREE_MAX_Y]).range([200, 400]);
 }
 
-function placeTreeOnMountain({x, name, id, height, mountains, scaleWidth, source = "archive", dbId, browserId}) {
+function buildMergedRanks(userTrees) {
+  const community = [...userTrees].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  const communityRanks = community.map((entry) => ({
+    name: entry.name,
+    id: entry.id,
+    source: "community",
+    dbId: entry.id,
+    browserId: entry.browserId,
+    createdAt: entry.createdAt,
+  }));
+
+  const archiveRanks = namesData.map((entry, index) => ({
+    name: entry.name,
+    id: entry.id ?? `archive-${index}`,
+    source: "archive",
+  }));
+
+  return [...communityRanks, ...archiveRanks];
+}
+
+function gapForSlot(slot, seed) {
+  return GAP_MIN + random(seed * 10000 + slot * 137) * (GAP_MAX - GAP_MIN);
+}
+
+function createSlotX(seed, originX) {
+  const cache = new Map();
+
+  function slotX(slot) {
+    if (cache.has(slot)) return cache.get(slot);
+
+    let x;
+    if (slot === 0) {
+      x = originX;
+    } else if (slot === 1) {
+      x = originX + gapForSlot(1, seed);
+    } else if (slot === 2) {
+      x = originX - gapForSlot(2, seed);
+    } else if (slot % 2 === 1) {
+      x = slotX(slot - 2) + gapForSlot(slot, seed);
+    } else {
+      x = slotX(slot - 2) - gapForSlot(slot, seed);
+    }
+
+    cache.set(slot, x);
+    return x;
+  }
+
+  return slotX;
+}
+
+function slotsInRange(startX, endX, seed, originX) {
+  const slotX = createSlotX(seed, originX);
+  const slots = [];
+
+  if (startX <= originX && originX <= endX) slots.push(0);
+
+  for (let s = 1; ; s += 2) {
+    const x = slotX(s);
+    if (x > endX) break;
+    slots.push(s);
+  }
+
+  for (let s = 2; ; s += 2) {
+    const x = slotX(s);
+    if (x < startX) break;
+    slots.push(s);
+  }
+
+  return slots.sort((a, b) => a - b);
+}
+
+function placeTreeOnMountain({x, name, id, height, mountains, scaleWidth, source = "archive", dbId, browserId, slot}) {
   const y = findYOnMountain(x, mountains);
   if (y === null || y < 0) return null;
   const py = Math.min(height - 20, y + TREE_DY);
@@ -187,70 +263,35 @@ function placeTreeOnMountain({x, name, id, height, mountains, scaleWidth, source
     source,
     dbId,
     browserId,
+    slot,
   };
 }
 
-function placeCommunityTrees({userTrees, height, mountains}) {
-  const scaleWidth = createTreeScaler();
-  const sorted = [...userTrees].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-  );
+function placeMergedTrees({userTrees, startX, endX, seed, height, mountains, centerX}) {
+  const ranks = buildMergedRanks(userTrees);
+  if (ranks.length === 0) return [];
 
-  return sorted
-    .map((entry, index) =>
-      placeTreeOnMountain({
-        x: -index * TREE_SPACING,
-        name: entry.name,
-        id: `user-${entry.id}`,
+  const slotX = createSlotX(seed, centerX);
+  const scaleWidth = createTreeScaler();
+  const slots = slotsInRange(startX, endX, seed, centerX);
+
+  return slots
+    .map((slot) => {
+      const rank = ranks[slot % ranks.length];
+      return placeTreeOnMountain({
+        x: slotX(slot),
+        name: rank.name,
+        id: `slot-${slot}-${rank.id}`,
         height,
         mountains,
         scaleWidth,
-        source: "community",
-        dbId: entry.id,
-        browserId: entry.browserId,
-      }),
-    )
+        source: rank.source,
+        dbId: rank.dbId,
+        browserId: rank.browserId,
+        slot,
+      });
+    })
     .filter(Boolean);
-}
-
-function isNearCommunityTree(px, communityXs, threshold = TREE_SPACING / 2) {
-  return communityXs.some((cx) => Math.abs(px - cx) < threshold);
-}
-
-function generateTrees({startX, endX, seed, height, mountains, communityXs = []}) {
-  const trees = [];
-  const randomName = (x) => random(x * 1000) * namesData.length;
-  const noiseSpacing = randomNoise(0, 1.2, {seed, octaves: 1, falloff: 0.5});
-  const scaleWidth = createTreeScaler();
-
-  function addTree(x) {
-    const px = x + TREE_SPACING * noiseSpacing(x);
-    if (isNearCommunityTree(px, communityXs)) return;
-    const nameIndex = Math.floor(randomName(x));
-    const placed = placeTreeOnMountain({
-      x: px,
-      name: namesData[nameIndex].name,
-      id: `tree-${Math.floor(px / 100)}-${nameIndex}`,
-      height,
-      mountains,
-      scaleWidth,
-      source: "archive",
-    });
-    if (placed) trees.push(placed);
-  }
-
-  let px;
-  for (px = 0; px < endX; px += TREE_SPACING) addTree(px);
-  for (px = -TREE_SPACING; px > startX; px -= TREE_SPACING) addTree(px);
-
-  return trees;
-}
-
-function mergeTrees({userTrees, startX, endX, seed, height, mountains}) {
-  const communityTrees = placeCommunityTrees({userTrees, height, mountains});
-  const communityXs = communityTrees.map((tree) => tree.x);
-  const archiveTrees = generateTrees({startX, endX, seed, height, mountains, communityXs});
-  return [...communityTrees, ...archiveTrees];
 }
 
 export function render({
@@ -265,8 +306,23 @@ export function render({
   userTrees = [],
 } = {}) {
   let communityTreesData = userTrees;
+  const centerX = currentX + width / 2;
   const state = {startX, endX, translateX, scaleX, currentX, offsetX: 0, x0: 0};
-  let latestCommunityY = height * 0.75;
+  let centerTreeY = height * 0.75;
+  let interactionLocked = false;
+  let pendingGrowDbId = null;
+  let growCompleteCallback = null;
+  let growStarted = false;
+
+  const defaultZoomFilter = (event) =>
+    (!event.ctrlKey || event.type === "wheel") && !event.button;
+
+  function setInteractionLocked(locked) {
+    interactionLocked = locked;
+    zoomBehavior.filter(locked ? () => false : defaultZoomFilter);
+    svg.style("pointer-events", locked ? "none" : "auto");
+    svg.style("cursor", locked ? "default" : "grab");
+  }
 
   const line = d3
     .line()
@@ -347,17 +403,18 @@ export function render({
 
     const mountains = [...farMountains, ...closeMountains];
 
-    const trees = mergeTrees({
+    const trees = placeMergedTrees({
       userTrees: communityTreesData,
       startX,
       endX,
       seed,
       height,
       mountains: closeMountains,
+      centerX,
     });
 
-    const newestCommunity = trees.find((tree) => tree.source === "community" && tree.x === 0);
-    if (newestCommunity) latestCommunityY = newestCommunity.y;
+    const centerTree = trees.find((tree) => tree.slot === 0);
+    if (centerTree) centerTreeY = centerTree.y;
 
     const scaledHeight = height * scaleX;
 
@@ -389,11 +446,15 @@ export function render({
     // Update trees
     const treeGroups = treesGroup.selectAll("g.tree-group").data(trees, (d) => d.id);
 
+    const growDbId = pendingGrowDbId;
+    pendingGrowDbId = null;
+
     treeGroups
       .enter()
       .append("g")
       .attr("class", "tree-group")
       .each(function (d) {
+        const group = this;
         const treeSvg = tree(d.name, {
           padding: 0,
           number: false,
@@ -402,7 +463,18 @@ export function render({
           width: d.width,
           strokeWidth: 1,
         }).render();
-        d3.select(this).append(() => treeSvg);
+        d3.select(group).append(() => treeSvg);
+
+        if (growDbId && d.slot === 0 && d.dbId === growDbId) {
+          growStarted = true;
+          setInteractionLocked(true);
+          prepareTreeForGrow(group);
+          animateTreeGrow(group).then(() => {
+              setInteractionLocked(false);
+              growCompleteCallback?.();
+              growCompleteCallback = null;
+            });
+        }
       })
       .merge(treeGroups)
       .attr("transform", (d) => {
@@ -422,8 +494,53 @@ export function render({
       communityTreesData = trees;
       update();
     },
-    panToWorldX(x) {
-      zoomBehavior.translateTo(svg, width / 2, height / 2, [x, latestCommunityY]);
+    setUserTreesAndGrow(trees, growDbId) {
+      return new Promise((resolve) => {
+        if (!growDbId) {
+          communityTreesData = trees;
+          update();
+          resolve();
+          return;
+        }
+
+        growStarted = false;
+        growCompleteCallback = resolve;
+        setInteractionLocked(true);
+
+        this.panToCenterAnimated().then(() => {
+          pendingGrowDbId = growDbId;
+          communityTreesData = trees;
+          update();
+          requestAnimationFrame(() => {
+            if (!growStarted) {
+              setInteractionLocked(false);
+              growCompleteCallback?.();
+              growCompleteCallback = null;
+            }
+          });
+        });
+      });
+    },
+    panToCenter() {
+      const k = 1;
+      const tx = width / 2 - centerX * k;
+      svg.call(zoomBehavior.transform, d3.zoomIdentity.translate(tx, 0).scale(k));
+    },
+    panToCenterAnimated(duration = 700) {
+      const k = 1;
+      const tx = width / 2 - centerX * k;
+      const target = d3.zoomIdentity.translate(tx, 0).scale(k);
+      return new Promise((resolve) => {
+        svg
+          .transition()
+          .duration(duration)
+          .ease(d3.easeCubicInOut)
+          .call(zoomBehavior.transform, target)
+          .on("end", resolve);
+      });
+    },
+    isInteractionLocked() {
+      return interactionLocked;
     },
   };
 }

--- a/src/render.js
+++ b/src/render.js
@@ -324,6 +324,68 @@ export function render({
     svg.style("cursor", locked ? "default" : "grab");
   }
 
+  function centerTransform() {
+    const k = 1;
+    const tx = width / 2 - centerX * k;
+    return d3.zoomIdentity.translate(tx, 0).scale(k);
+  }
+
+  function transformForWorldX(worldX, k = 1) {
+    return d3.zoomIdentity.translate(width / 2 - worldX * k, 0).scale(k);
+  }
+
+  function isAtTransform(target) {
+    const current = d3.zoomTransform(svg.node());
+    const epsilon = 0.5;
+    return (
+      Math.abs(current.x - target.x) < epsilon &&
+      Math.abs(current.y - target.y) < epsilon &&
+      Math.abs(current.k - target.k) < 0.001
+    );
+  }
+
+  function getWorldXForDbId(dbId) {
+    const ranks = buildMergedRanks(communityTreesData);
+    const rankIndex = ranks.findIndex((rank) => rank.dbId === dbId);
+    if (rankIndex < 0) return null;
+
+    const slotX = createSlotX(seed, centerX);
+    const viewCenterX = (width / 2 - state.translateX) / state.scaleX;
+    const n = ranks.length;
+    const originX = slotX(rankIndex);
+    const approxGap = (GAP_MIN + GAP_MAX) / 2;
+    const deltaSlots = Math.ceil(Math.abs(viewCenterX - originX) / approxGap / n) + 2;
+
+    let bestSlot = rankIndex;
+    let bestDist = Infinity;
+    for (let k = -deltaSlots; k <= deltaSlots; k++) {
+      const slot = rankIndex + k * n;
+      if (slot < 0) continue;
+      const x = slotX(slot);
+      const dist = Math.abs(x - viewCenterX);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestSlot = slot;
+      }
+    }
+
+    return slotX(bestSlot);
+  }
+
+  function panToTransformAnimated(target, duration = 700) {
+    if (isAtTransform(target)) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      svg
+        .transition()
+        .duration(duration)
+        .ease(d3.easeCubicInOut)
+        .call(zoomBehavior.transform, target)
+        .on("end", resolve);
+    });
+  }
+
   const line = d3
     .line()
     .x((d) => d.x)
@@ -522,22 +584,15 @@ export function render({
       });
     },
     panToCenter() {
-      const k = 1;
-      const tx = width / 2 - centerX * k;
-      svg.call(zoomBehavior.transform, d3.zoomIdentity.translate(tx, 0).scale(k));
+      svg.call(zoomBehavior.transform, centerTransform());
     },
     panToCenterAnimated(duration = 700) {
-      const k = 1;
-      const tx = width / 2 - centerX * k;
-      const target = d3.zoomIdentity.translate(tx, 0).scale(k);
-      return new Promise((resolve) => {
-        svg
-          .transition()
-          .duration(duration)
-          .ease(d3.easeCubicInOut)
-          .call(zoomBehavior.transform, target)
-          .on("end", resolve);
-      });
+      return panToTransformAnimated(centerTransform(), duration);
+    },
+    panToTreeAnimated(dbId, duration = 700) {
+      const worldX = getWorldXForDbId(dbId);
+      if (worldX === null) return Promise.resolve();
+      return panToTransformAnimated(transformForWorldX(worldX, 1), duration);
     },
     isInteractionLocked() {
       return interactionLocked;

--- a/src/render.js
+++ b/src/render.js
@@ -296,7 +296,7 @@ function placeMergedTrees({userTrees, startX, endX, seed, height, mountains, cen
 
 export function render({
   width = 1000,
-  height = 600,
+  height = 540,
   currentX = 0,
   startX = currentX - width,
   endX = currentX + width * 2,

--- a/src/render.js
+++ b/src/render.js
@@ -165,36 +165,92 @@ function findYOnMountain(x, mountains) {
   return null;
 }
 
-function generateTrees({startX, endX, seed, height, mountains}) {
-  const spacing = 350;
+const TREE_SPACING = 350;
+const TREE_DY = 40;
+const TREE_MIN_Y = 420;
+const TREE_MAX_Y = 640;
+
+function createTreeScaler() {
+  return d3.scaleSqrt().domain([TREE_MIN_Y, TREE_MAX_Y]).range([200, 400]);
+}
+
+function placeTreeOnMountain({x, name, id, height, mountains, scaleWidth, source = "archive", dbId, browserId}) {
+  const y = findYOnMountain(x, mountains);
+  if (y === null || y < 0) return null;
+  const py = Math.min(height - 20, y + TREE_DY);
+  return {
+    x,
+    y: py,
+    width: scaleWidth(py),
+    name,
+    id,
+    source,
+    dbId,
+    browserId,
+  };
+}
+
+function placeCommunityTrees({userTrees, height, mountains}) {
+  const scaleWidth = createTreeScaler();
+  const sorted = [...userTrees].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  return sorted
+    .map((entry, index) =>
+      placeTreeOnMountain({
+        x: -index * TREE_SPACING,
+        name: entry.name,
+        id: `user-${entry.id}`,
+        height,
+        mountains,
+        scaleWidth,
+        source: "community",
+        dbId: entry.id,
+        browserId: entry.browserId,
+      }),
+    )
+    .filter(Boolean);
+}
+
+function isNearCommunityTree(px, communityXs, threshold = TREE_SPACING / 2) {
+  return communityXs.some((cx) => Math.abs(px - cx) < threshold);
+}
+
+function generateTrees({startX, endX, seed, height, mountains, communityXs = []}) {
   const trees = [];
   const randomName = (x) => random(x * 1000) * namesData.length;
   const noiseSpacing = randomNoise(0, 1.2, {seed, octaves: 1, falloff: 0.5});
-
-  const dy = 40;
-
-  // Fixed Y range for trees for consistent y position.
-  const minY = 420;
-  const maxY = 640;
-  const scaleWidth = d3.scaleSqrt().domain([minY, maxY]).range([200, 400]);
+  const scaleWidth = createTreeScaler();
 
   function addTree(x) {
-    const px = x + spacing * noiseSpacing(x);
-    const y = findYOnMountain(px, mountains);
-    if (y !== null && y >= 0) {
-      const nameIndex = Math.floor(randomName(x));
-      const name = namesData[nameIndex].name;
-      const py = Math.min(height - 20, y + dy);
-      const treeWidth = scaleWidth(py);
-      trees.push({x: px, y: py, width: treeWidth, name, id: `tree-${Math.floor(px / 100)}-${nameIndex}`});
-    }
+    const px = x + TREE_SPACING * noiseSpacing(x);
+    if (isNearCommunityTree(px, communityXs)) return;
+    const nameIndex = Math.floor(randomName(x));
+    const placed = placeTreeOnMountain({
+      x: px,
+      name: namesData[nameIndex].name,
+      id: `tree-${Math.floor(px / 100)}-${nameIndex}`,
+      height,
+      mountains,
+      scaleWidth,
+      source: "archive",
+    });
+    if (placed) trees.push(placed);
   }
 
   let px;
-  for (px = 0; px < endX; px += spacing) addTree(px);
-  for (px = -spacing; px > startX; px -= spacing) addTree(px);
+  for (px = 0; px < endX; px += TREE_SPACING) addTree(px);
+  for (px = -TREE_SPACING; px > startX; px -= TREE_SPACING) addTree(px);
 
   return trees;
+}
+
+function mergeTrees({userTrees, startX, endX, seed, height, mountains}) {
+  const communityTrees = placeCommunityTrees({userTrees, height, mountains});
+  const communityXs = communityTrees.map((tree) => tree.x);
+  const archiveTrees = generateTrees({startX, endX, seed, height, mountains, communityXs});
+  return [...communityTrees, ...archiveTrees];
 }
 
 export function render({
@@ -206,8 +262,11 @@ export function render({
   translateX = 0,
   scaleX = 1,
   seed = 10000,
+  userTrees = [],
 } = {}) {
+  let communityTreesData = userTrees;
   const state = {startX, endX, translateX, scaleX, currentX, offsetX: 0, x0: 0};
+  let latestCommunityY = height * 0.75;
 
   const line = d3
     .line()
@@ -288,7 +347,17 @@ export function render({
 
     const mountains = [...farMountains, ...closeMountains];
 
-    const trees = generateTrees({startX, endX, seed, height, mountains: closeMountains});
+    const trees = mergeTrees({
+      userTrees: communityTreesData,
+      startX,
+      endX,
+      seed,
+      height,
+      mountains: closeMountains,
+    });
+
+    const newestCommunity = trees.find((tree) => tree.source === "community" && tree.x === 0);
+    if (newestCommunity) latestCommunityY = newestCommunity.y;
 
     const scaledHeight = height * scaleX;
 
@@ -347,5 +416,14 @@ export function render({
     treeGroups.exit().remove();
   }
 
-  return svg.node();
+  return {
+    node: svg.node(),
+    setUserTrees(trees) {
+      communityTreesData = trees;
+      update();
+    },
+    panToWorldX(x) {
+      zoomBehavior.translateTo(svg, width / 2, height / 2, [x, latestCommunityY]);
+    },
+  };
 }

--- a/src/tree.js
+++ b/src/tree.js
@@ -155,12 +155,12 @@ export function tree(
   const initLen = (140 / 480) * width;
   const baselineY = height * 0.618 + initLen;
   const context = cm.mat().translate(width / 2, baselineY);
-  branch(root, initLen, 0, 80);
+  branch(root, initLen, 0, 80, 0, 1);
 
-  function branch(node, len, rotation, angle, roseCount = 0) {
+  function branch(node, len, rotation, angle, roseCount = 0, depth = 1) {
     context.push();
     context.rotate(rotation);
-    paths.push({d: `M0,0L0,${-len}`, transform: context.transform()});
+    paths.push({d: `M0,0L0,${-len}`, transform: context.transform(), depth});
 
     if (node.children) {
       context.translate(0, -len);
@@ -204,7 +204,7 @@ export function tree(
         const childRotation = scaleAngle(stacked[i]);
         const prevRotation = stacked[prevIndex] ? scaleAngle(stacked[prevIndex]) : -angle;
         const diff = childRotation - prevRotation;
-        branch(child, len, (childRotation + prevRotation) / 2, Math.min(80, diff), isMerge ? mergeCount : 0);
+        branch(child, len, (childRotation + prevRotation) / 2, Math.min(80, diff), isMerge ? mergeCount : 0, depth + 1);
       }
     } else {
       // [n, d]
@@ -222,7 +222,7 @@ export function tree(
         const [n, d] = roseByCount[roseCount];
         const r = Math.sqrt(roseCount * len);
         context.translate(0, -len);
-        roses.push({r, n, d, transform: context.transform()});
+        roses.push({r, n, d, transform: context.transform(), depth});
       } else {
         const r = len / 12;
         context.translate(0, -len - r);
@@ -232,6 +232,7 @@ export function tree(
           cy: 0,
           r,
           transform: context.transform(),
+          depth,
         });
       }
     }
@@ -261,6 +262,7 @@ export function tree(
     const start = end ? width - totalLength : width / 2 + padding;
     const sw = 1.5;
     textNode = cm.svg("g", {
+      "data-tree-part": "name",
       transform: `translate(${start}, ${baselineY - cellSize - 5})`,
       children: [
         apack.text(text, {
@@ -280,6 +282,7 @@ export function tree(
     const dx = (-20 / 480) * width;
     const dy = (-55 / 480) * width;
     textNode = cm.svg("g", {
+      "data-tree-part": "name",
       children: [
         cm.svg("rect", {
           x: width + dx - textWidth - textPadding,
@@ -321,12 +324,14 @@ export function tree(
           fill: "transparent",
         }),
       cm.svg("g", flowers, {
+        "data-tree-part": "flower",
         transform: (d, i) => `translate(${flowerX(i)}, ${baselineY})`,
         children: (d, i) => [
           cm.svg("path", {
             d: `M0,0L0,${-initLen * 0.618}`,
             stroke: "black",
             strokeWidth,
+            "data-tree-part": "flower",
           }),
           cm.svg("g", {
             strokeWidth,
@@ -335,6 +340,7 @@ export function tree(
               rose(12, 1, i + 2, {
                 fill: THEME.background,
                 stroke: "black",
+                "data-tree-part": "flower",
               }),
             ],
           }),
@@ -348,6 +354,8 @@ export function tree(
             cm.svg("path", paths, {
               d: (d) => d.d,
               transform: (d) => d.transform,
+              "data-tree-part": "branch",
+              "data-depth": (d) => d.depth,
             }),
           ],
         }),
@@ -360,6 +368,8 @@ export function tree(
                 d: circlePath(d.r),
                 fill: THEME.background,
                 stroke: "black",
+                "data-tree-part": "flower",
+                "data-depth": (d) => d.depth,
               }),
             ].filter(Boolean),
         }),
@@ -370,6 +380,8 @@ export function tree(
             rose(d.r, d.n, d.d, {
               fill: THEME.background,
               stroke: "black",
+              "data-tree-part": "flower",
+              "data-depth": (d) => d.depth,
             }),
           ],
         }),

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,267 @@
+import {tree} from "./tree.js";
+import {getBrowserId} from "./lib/browserId.js";
+import {isSupabaseConfigured} from "./lib/landscapeTreesApi.js";
+import {validateName} from "./lib/validateName.js";
+
+const PREVIEW_OPTIONS = {grid: false, padding: 0, number: false, line: false, end: false};
+const THUMB_OPTIONS = {grid: false, padding: 0, number: false, line: false, end: false, width: 200};
+
+function renderTreePreview(container, name, options = PREVIEW_OPTIONS) {
+  container.innerHTML = "";
+  const text = name.trim() || "Name To Tree";
+  const node = tree(text, options).render();
+  node.setAttribute("viewBox", "0 0 480 480");
+  node.style.width = "100%";
+  node.style.height = "100%";
+  container.appendChild(node);
+}
+
+function createModal({title, onClose}) {
+  const overlay = document.createElement("div");
+  overlay.className = "modal-overlay";
+  overlay.addEventListener("click", (event) => {
+    if (event.target === overlay) onClose();
+  });
+
+  const dialog = document.createElement("div");
+  dialog.className = "modal-dialog";
+  dialog.addEventListener("click", (event) => event.stopPropagation());
+
+  const header = document.createElement("div");
+  header.className = "modal-header";
+
+  const heading = document.createElement("h2");
+  heading.className = "modal-title";
+  heading.textContent = title;
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "modal-close";
+  closeButton.setAttribute("aria-label", "Close");
+  closeButton.textContent = "×";
+  closeButton.addEventListener("click", onClose);
+
+  header.append(heading, closeButton);
+  dialog.appendChild(header);
+  overlay.appendChild(dialog);
+
+  const onKeyDown = (event) => {
+    if (event.key === "Escape") onClose();
+  };
+  document.addEventListener("keydown", onKeyDown);
+
+  return {
+    overlay,
+    dialog,
+    destroy() {
+      document.removeEventListener("keydown", onKeyDown);
+      overlay.remove();
+    },
+  };
+}
+
+function createDeleteButton(onDelete) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "my-tree-delete";
+  button.setAttribute("aria-label", "Delete tree");
+
+  const dot = document.createElement("span");
+  dot.className = "my-tree-dot";
+  dot.textContent = "*";
+
+  const trash = document.createElement("span");
+  trash.className = "my-tree-trash";
+  trash.innerHTML =
+    '<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>';
+
+  button.append(dot, trash);
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    onDelete();
+  });
+  return button;
+}
+
+export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
+  const toolbar = document.createElement("div");
+  toolbar.className = "toolbar";
+
+  const plantButton = document.createElement("button");
+  plantButton.type = "button";
+  plantButton.className = "toolbar-btn toolbar-btn-primary";
+  plantButton.textContent = "+ Plant";
+
+  const myTreesButton = document.createElement("button");
+  myTreesButton.type = "button";
+  myTreesButton.className = "toolbar-btn toolbar-btn-secondary";
+  myTreesButton.textContent = "My trees";
+
+  toolbar.append(plantButton, myTreesButton);
+  document.body.appendChild(toolbar);
+
+  let activeModal = null;
+
+  function closeModal() {
+    if (activeModal) {
+      activeModal.destroy();
+      activeModal = null;
+    }
+  }
+
+  function openAddModal() {
+    closeModal();
+    if (!isSupabaseConfigured()) {
+      openMessageModal("Not connected", "Planting is not available yet. Please try again later.");
+      return;
+    }
+
+    const modal = createModal({title: "Plant your tree", onClose: closeModal});
+    activeModal = modal;
+
+    const body = document.createElement("div");
+    body.className = "modal-body";
+
+    const preview = document.createElement("div");
+    preview.className = "modal-preview";
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "modal-input";
+    input.placeholder = "Type your name or a short phrase…";
+    input.maxLength = 80;
+    input.autocomplete = "off";
+
+    const error = document.createElement("p");
+    error.className = "modal-error";
+    error.hidden = true;
+
+    const actions = document.createElement("div");
+    actions.className = "modal-actions";
+
+    const submit = document.createElement("button");
+    submit.type = "button";
+    submit.className = "toolbar-btn toolbar-btn-primary";
+    submit.textContent = "Plant your tree";
+
+    actions.appendChild(submit);
+    body.append(preview, input, error, actions);
+    modal.dialog.appendChild(body);
+    document.body.appendChild(modal.overlay);
+
+    renderTreePreview(preview, input.value);
+    input.focus();
+
+    input.addEventListener("input", () => {
+      error.hidden = true;
+      renderTreePreview(preview, input.value);
+    });
+
+    async function handleSubmit() {
+      const validation = validateName(input.value);
+      if (!validation.ok) {
+        error.textContent = validation.error;
+        error.hidden = false;
+        return;
+      }
+
+      submit.disabled = true;
+      submit.textContent = "Planting…";
+      error.hidden = true;
+
+      try {
+        await onAdd(validation.name);
+        closeModal();
+      } catch (err) {
+        error.textContent = err.message ?? "Could not plant your tree. Please try again.";
+        error.hidden = false;
+        submit.disabled = false;
+        submit.textContent = "Plant your tree";
+      }
+    }
+
+    submit.addEventListener("click", handleSubmit);
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") handleSubmit();
+    });
+  }
+
+  function openMessageModal(title, message) {
+    closeModal();
+    const modal = createModal({title, onClose: closeModal});
+    activeModal = modal;
+
+    const body = document.createElement("p");
+    body.className = "modal-message";
+    body.textContent = message;
+    modal.dialog.appendChild(body);
+    document.body.appendChild(modal.overlay);
+  }
+
+  function openMyTreesModal() {
+    closeModal();
+    if (!isSupabaseConfigured()) {
+      openMessageModal("Not connected", "Your trees are not available yet. Please try again later.");
+      return;
+    }
+
+    const modal = createModal({title: "My trees", onClose: closeModal});
+    activeModal = modal;
+
+    const body = document.createElement("div");
+    body.className = "modal-body my-trees-body";
+    modal.dialog.appendChild(body);
+    document.body.appendChild(modal.overlay);
+
+    const browserId = getBrowserId();
+    const ownTrees = getUserTrees().filter((entry) => entry.browserId === browserId);
+
+    if (ownTrees.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "modal-message";
+      empty.textContent = "You haven't planted a tree here yet.";
+      body.appendChild(empty);
+      return;
+    }
+
+    const grid = document.createElement("div");
+    grid.className = "my-trees-grid";
+
+    for (const entry of ownTrees) {
+      const cell = document.createElement("div");
+      cell.className = "my-tree-cell";
+
+      const thumb = document.createElement("div");
+      thumb.className = "my-tree-thumb";
+      renderTreePreview(thumb, entry.name, THUMB_OPTIONS);
+
+      const label = document.createElement("p");
+      label.className = "my-tree-label";
+      label.textContent = entry.name;
+
+      cell.append(
+        thumb,
+        label,
+        createDeleteButton(async () => {
+          if (!confirm(`Remove "${entry.name}" from the landscape?`)) return;
+          try {
+            await onDelete(entry.id);
+            await refreshUserTrees();
+            closeModal();
+            openMyTreesModal();
+          } catch (err) {
+            openMessageModal("Could not delete", err.message ?? "Please try again.");
+          }
+        }),
+      );
+      grid.appendChild(cell);
+    }
+
+    body.appendChild(grid);
+  }
+
+  plantButton.addEventListener("click", openAddModal);
+  myTreesButton.addEventListener("click", openMyTreesModal);
+
+  return {closeModal};
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -165,18 +165,13 @@ export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
         return;
       }
 
-      submit.disabled = true;
-      submit.textContent = "Planting…";
-      error.hidden = true;
+      const name = validation.name;
+      closeModal();
 
       try {
-        await onAdd(validation.name);
-        closeModal();
+        await onAdd(name);
       } catch (err) {
-        error.textContent = err.message ?? "Could not plant your tree. Please try again.";
-        error.hidden = false;
-        submit.disabled = false;
-        submit.textContent = "Plant your tree";
+        openMessageModal("Could not plant", err.message ?? "Please try again.");
       }
     }
 
@@ -263,5 +258,11 @@ export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
   plantButton.addEventListener("click", openAddModal);
   myTreesButton.addEventListener("click", openMyTreesModal);
 
-  return {closeModal};
+  function setInteractionBlocked(blocked) {
+    document.body.classList.toggle("interaction-blocked", blocked);
+    plantButton.disabled = blocked;
+    myTreesButton.disabled = blocked;
+  }
+
+  return {closeModal, setInteractionBlocked};
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,18 +1,23 @@
 import {tree} from "./tree.js";
+import namesData from "./names.json";
 import {getBrowserId} from "./lib/browserId.js";
 import {isSupabaseConfigured} from "./lib/landscapeTreesApi.js";
 import {validateName} from "./lib/validateName.js";
 
 const PREVIEW_OPTIONS = {grid: false, padding: 0, number: false, line: false, end: false};
-const THUMB_OPTIONS = {grid: false, padding: 0, number: false, line: false, end: false, width: 200};
+const THUMB_OPTIONS = {grid: false, padding: 0, number: false, line: false, end: false};
 
 function renderTreePreview(container, name, options = PREVIEW_OPTIONS) {
   container.innerHTML = "";
   const text = name.trim() || "Name To Tree";
-  const node = tree(text, options).render();
-  node.setAttribute("viewBox", "0 0 480 480");
+  const width = options.width ?? 480;
+  const height = options.height ?? width;
+  const node = tree(text, {...options, width, height}).render();
+  node.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  node.setAttribute("preserveAspectRatio", "xMidYMid meet");
   node.style.width = "100%";
   node.style.height = "100%";
+  node.style.display = "block";
   container.appendChild(node);
 }
 
@@ -60,30 +65,42 @@ function createModal({title, onClose}) {
   };
 }
 
-function createDeleteButton(onDelete) {
+function createTreeActionButton({className, label, icon, onClick}) {
   const button = document.createElement("button");
   button.type = "button";
-  button.className = "my-tree-delete";
-  button.setAttribute("aria-label", "Delete tree");
-
-  const dot = document.createElement("span");
-  dot.className = "my-tree-dot";
-  dot.textContent = "*";
-
-  const trash = document.createElement("span");
-  trash.className = "my-tree-trash";
-  trash.innerHTML =
-    '<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>';
-
-  button.append(dot, trash);
+  button.className = `my-tree-action ${className}`;
+  button.setAttribute("aria-label", label);
+  button.innerHTML = icon;
   button.addEventListener("click", (event) => {
     event.stopPropagation();
-    onDelete();
+    onClick();
   });
   return button;
 }
 
-export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
+function createTreeActions({onFocus, onDelete}) {
+  const actions = document.createElement("div");
+  actions.className = "my-tree-actions";
+  actions.append(
+    createTreeActionButton({
+      className: "my-tree-focus",
+      label: "Focus on tree",
+      icon:
+        '<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm8.94 3A8.994 8.994 0 0 0 13 3.06V1h-2v2.06A8.994 8.994 0 0 0 3.06 11H1v2h2.06A8.994 8.994 0 0 0 11 20.94V23h2v-2.06A8.994 8.994 0 0 0 20.94 13H23v-2h-2.06zM12 19c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"/></svg>',
+      onClick: onFocus,
+    }),
+    createTreeActionButton({
+      className: "my-tree-delete",
+      label: "Delete tree",
+      icon:
+        '<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>',
+      onClick: onDelete,
+    }),
+  );
+  return actions;
+}
+
+export function initUI({onAdd, onDelete, onFocusTree, getUserTrees, refreshUserTrees}) {
   const toolbar = document.createElement("div");
   toolbar.className = "toolbar";
 
@@ -99,6 +116,28 @@ export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
 
   toolbar.append(plantButton, myTreesButton);
   document.body.appendChild(toolbar);
+
+  const totalTreesEl = document.createElement("p");
+  totalTreesEl.className = "tree-count";
+  document.querySelector(".content")?.appendChild(totalTreesEl);
+
+  function ownTreeCount() {
+    const browserId = getBrowserId();
+    return getUserTrees().filter((entry) => entry.browserId === browserId).length;
+  }
+
+  function myTreesLabel() {
+    return `My trees (${ownTreeCount()})`;
+  }
+
+  function totalTreeCount() {
+    return getUserTrees().length + namesData.length;
+  }
+
+  function updateTreeCounts() {
+    myTreesButton.textContent = myTreesLabel();
+    totalTreesEl.textContent = `${totalTreeCount().toLocaleString()} trees in the landscape`;
+  }
 
   let activeModal = null;
 
@@ -200,7 +239,8 @@ export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
       return;
     }
 
-    const modal = createModal({title: "My trees", onClose: closeModal});
+    const modal = createModal({title: myTreesLabel(), onClose: closeModal});
+    modal.dialog.classList.add("modal-dialog-my-trees");
     activeModal = modal;
 
     const body = document.createElement("div");
@@ -237,16 +277,22 @@ export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
       cell.append(
         thumb,
         label,
-        createDeleteButton(async () => {
-          if (!confirm(`Remove "${entry.name}" from the landscape?`)) return;
-          try {
-            await onDelete(entry.id);
-            await refreshUserTrees();
+        createTreeActions({
+          onFocus: () => {
             closeModal();
-            openMyTreesModal();
-          } catch (err) {
-            openMessageModal("Could not delete", err.message ?? "Please try again.");
-          }
+            void onFocusTree(entry.id);
+          },
+          onDelete: async () => {
+            if (!confirm(`Remove "${entry.name}" from the landscape?`)) return;
+            try {
+              await onDelete(entry.id);
+              await refreshUserTrees();
+              closeModal();
+              openMyTreesModal();
+            } catch (err) {
+              openMessageModal("Could not delete", err.message ?? "Please try again.");
+            }
+          },
         }),
       );
       grid.appendChild(cell);
@@ -257,6 +303,7 @@ export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
 
   plantButton.addEventListener("click", openAddModal);
   myTreesButton.addEventListener("click", openMyTreesModal);
+  updateTreeCounts();
 
   function setInteractionBlocked(blocked) {
     document.body.classList.toggle("interaction-blocked", blocked);
@@ -264,5 +311,5 @@ export function initUI({onAdd, onDelete, getUserTrees, refreshUserTrees}) {
     myTreesButton.disabled = blocked;
   }
 
-  return {closeModal, setInteractionBlocked};
+  return {closeModal, setInteractionBlocked, updateTreeCounts};
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -223,6 +223,11 @@ export function initUI({onAdd, onDelete, onFocusTree, getUserTrees, refreshUserT
     });
     activeModal = modal;
 
+    const privacy = document.createElement("p");
+    privacy.className = "modal-privacy";
+    privacy.textContent =
+      "Your name will appear publicly in the landscape. It is stored only for this project and not used for anything else. You can delete your trees anytime in My trees.";
+
     const error = document.createElement("p");
     error.className = "modal-error";
     error.hidden = true;
@@ -236,7 +241,7 @@ export function initUI({onAdd, onDelete, onFocusTree, getUserTrees, refreshUserT
     submit.textContent = "Plant your tree";
 
     actions.appendChild(submit);
-    body.append(preview, input, error, actions);
+    body.append(preview, input, privacy, error, actions);
     modal.dialog.appendChild(body);
     document.body.appendChild(modal.overlay);
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,5 +1,6 @@
 import {tree} from "./tree.js";
 import namesData from "./names.json";
+import {createHowItWorksPanel} from "./howItWorks.js";
 import {getBrowserId} from "./lib/browserId.js";
 import {isSupabaseConfigured} from "./lib/landscapeTreesApi.js";
 import {validateName} from "./lib/validateName.js";
@@ -21,16 +22,24 @@ function renderTreePreview(container, name, options = PREVIEW_OPTIONS) {
   container.appendChild(node);
 }
 
-function createModal({title, onClose}) {
+function createModal({title, onClose, getHelpSample}) {
+  let helpPanel = null;
+
   const overlay = document.createElement("div");
   overlay.className = "modal-overlay";
   overlay.addEventListener("click", (event) => {
     if (event.target === overlay) onClose();
   });
 
+  const group = document.createElement("div");
+  group.className = "modal-group";
+
   const dialog = document.createElement("div");
   dialog.className = "modal-dialog";
-  dialog.addEventListener("click", (event) => event.stopPropagation());
+  dialog.addEventListener("click", (event) => {
+    event.stopPropagation();
+    closeHelp();
+  });
 
   const header = document.createElement("div");
   header.className = "modal-header";
@@ -39,6 +48,16 @@ function createModal({title, onClose}) {
   heading.className = "modal-title";
   heading.textContent = title;
 
+  const headerActions = document.createElement("div");
+  headerActions.className = "modal-header-actions";
+
+  const helpButton = document.createElement("button");
+  helpButton.type = "button";
+  helpButton.className = "modal-help";
+  helpButton.setAttribute("aria-label", "How it works");
+  helpButton.setAttribute("aria-pressed", "false");
+  helpButton.textContent = "?";
+
   const closeButton = document.createElement("button");
   closeButton.type = "button";
   closeButton.className = "modal-close";
@@ -46,9 +65,36 @@ function createModal({title, onClose}) {
   closeButton.textContent = "×";
   closeButton.addEventListener("click", onClose);
 
-  header.append(heading, closeButton);
+  headerActions.append(helpButton, closeButton);
+  header.append(heading, headerActions);
   dialog.appendChild(header);
-  overlay.appendChild(dialog);
+  group.appendChild(dialog);
+  overlay.appendChild(group);
+
+  function closeHelp() {
+    if (!helpPanel) return;
+    helpPanel.remove();
+    helpPanel = null;
+    group.classList.remove("modal-group-with-help");
+    helpButton.setAttribute("aria-pressed", "false");
+  }
+
+  function openHelp() {
+    if (helpPanel) return;
+    helpPanel = createHowItWorksPanel({
+      getSample: getHelpSample ?? (() => "AB"),
+      onClose: closeHelp,
+    });
+    group.classList.add("modal-group-with-help");
+    group.appendChild(helpPanel);
+    helpButton.setAttribute("aria-pressed", "true");
+  }
+
+  helpButton.addEventListener("click", (event) => {
+    event.stopPropagation();
+    if (helpPanel) closeHelp();
+    else openHelp();
+  });
 
   const onKeyDown = (event) => {
     if (event.key === "Escape") onClose();
@@ -58,8 +104,10 @@ function createModal({title, onClose}) {
   return {
     overlay,
     dialog,
+    closeHelp,
     destroy() {
       document.removeEventListener("keydown", onKeyDown);
+      closeHelp();
       overlay.remove();
     },
   };
@@ -155,9 +203,6 @@ export function initUI({onAdd, onDelete, onFocusTree, getUserTrees, refreshUserT
       return;
     }
 
-    const modal = createModal({title: "Plant your tree", onClose: closeModal});
-    activeModal = modal;
-
     const body = document.createElement("div");
     body.className = "modal-body";
 
@@ -170,6 +215,13 @@ export function initUI({onAdd, onDelete, onFocusTree, getUserTrees, refreshUserT
     input.placeholder = "Type your name or a short phrase…";
     input.maxLength = 80;
     input.autocomplete = "off";
+
+    const modal = createModal({
+      title: "Plant your tree",
+      onClose: closeModal,
+      getHelpSample: () => input.value,
+    });
+    activeModal = modal;
 
     const error = document.createElement("p");
     error.className = "modal-error";

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,317 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "infinite-landscape"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+[edge_runtime]
+enabled = true
+# Configure one of the supported request policies: `oneshot`, `per_worker`.
+# Use `oneshot` for hot reload, or `per_worker` for load testing.
+policy = "oneshot"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 1
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/supabase/landscape_trees.sql
+++ b/supabase/landscape_trees.sql
@@ -1,0 +1,34 @@
+-- Landscape community trees table (run in Supabase SQL Editor)
+
+create table public.landscape_trees (
+  id uuid primary key default gen_random_uuid(),
+  name text not null check (char_length(trim(name)) between 1 and 80),
+  browser_id text not null check (char_length(browser_id) >= 8),
+  created_at timestamptz not null default now()
+);
+
+create index landscape_trees_created_at_idx on public.landscape_trees (created_at desc);
+
+alter table public.landscape_trees enable row level security;
+
+create policy "landscape_trees_select_public"
+  on public.landscape_trees for select
+  to anon, authenticated
+  using (true);
+
+create policy "landscape_trees_insert_public"
+  on public.landscape_trees for insert
+  to anon, authenticated
+  with check (char_length(trim(name)) between 1 and 80);
+
+create policy "landscape_trees_delete_own"
+  on public.landscape_trees for delete
+  to anon, authenticated
+  using (
+    browser_id = coalesce(
+      (current_setting('request.headers', true)::json ->> 'x-browser-id'),
+      ''
+    )
+  );
+
+grant select, insert, delete on public.landscape_trees to anon, authenticated;

--- a/supabase/migrations/20260605230000_landscape_trees.sql
+++ b/supabase/migrations/20260605230000_landscape_trees.sql
@@ -1,0 +1,34 @@
+-- Landscape community trees table (run in Supabase SQL Editor)
+
+create table public.landscape_trees (
+  id uuid primary key default gen_random_uuid(),
+  name text not null check (char_length(trim(name)) between 1 and 80),
+  browser_id text not null check (char_length(browser_id) >= 8),
+  created_at timestamptz not null default now()
+);
+
+create index landscape_trees_created_at_idx on public.landscape_trees (created_at desc);
+
+alter table public.landscape_trees enable row level security;
+
+create policy "landscape_trees_select_public"
+  on public.landscape_trees for select
+  to anon, authenticated
+  using (true);
+
+create policy "landscape_trees_insert_public"
+  on public.landscape_trees for insert
+  to anon, authenticated
+  with check (char_length(trim(name)) between 1 and 80);
+
+create policy "landscape_trees_delete_own"
+  on public.landscape_trees for delete
+  to anon, authenticated
+  using (
+    browser_id = coalesce(
+      (current_setting('request.headers', true)::json ->> 'x-browser-id'),
+      ''
+    )
+  );
+
+grant select, insert, delete on public.landscape_trees to anon, authenticated;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Supabase-backed community planting with a new `landscape_trees` table, shared `name2tree_browser_id`, and the same profanity/validation rules as tree.bairui.dev
- Merge community trees (newest first) with the `names.json` archive in a center-out slot layout; slot 0 sits at screen center and loops infinitely as you pan
- Planting runs a grow animation and smooth camera pan to scale 1 (skipped if already centered)
- Add **+ Plant** / **My trees (n)** toolbar, a landscape tree count, privacy note in the plant modal, and a **?** how-it-works panel (5 steps with wiki links)
- **My trees** gallery: horizontal scroll, focus-to-tree, delete; wider modal for multiple cards
- UI polish: Newsreader + IBM Plex Mono, top-right GitHub icon, modal layout fixes
- Merge `main` (includes Vercel Web Analytics)

## Test plan
- [x] Run `supabase/landscape_trees.sql` (or migration) if not already applied
- [x] `cp .env.example .env.local`, set Supabase vars, `pnpm dev`
- [x] Plant a tree → preview updates, validation rejects bad words/URLs, grow animation plays, camera pans to center at scale 1
- [x] Plant again while already centered → no redundant camera transition
- [x] **My trees (n)** shows your count; gallery scrolls horizontally; **focus** pans to a tree; **delete** removes yours only
- [x] Bottom-right shows total trees in landscape (community + archive)
- [x] **?** opens how-it-works steps; links work (ASCII, rose, APack); step 4 uses `ego` example
- [x] Privacy note visible in plant modal
- [x] Landscape still loads without `.env.local` (friendly not-connected message)
- [x] Resize / `?show=true` kiosk mode still works
- [x] Set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` on Vercel before merging to production