### PR TITLE
Add URL seed persistence and Remix landscape button

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,44 @@
       gap: 8px;
     }
 
+    .toolbar-item-with-tooltip {
+      position: relative;
+      display: flex;
+    }
+
+    .toolbar-tooltip {
+      position: absolute;
+      top: calc(100% + 8px);
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 1;
+      width: max-content;
+      max-width: 220px;
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1.5px solid var(--ink);
+      background: rgba(254, 250, 241, 0.96);
+      color: var(--ink);
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 400;
+      line-height: 1.4;
+      text-align: center;
+      letter-spacing: 0.01em;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+      backdrop-filter: blur(4px);
+      pointer-events: none;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.15s ease, visibility 0.15s ease;
+    }
+
+    .toolbar-item-with-tooltip:hover .toolbar-tooltip,
+    .toolbar-item-with-tooltip:focus-within .toolbar-tooltip {
+      opacity: 1;
+      visibility: visible;
+    }
+
     .toolbar-btn {
       font-family: var(--font-mono);
       font-size: 13px;

--- a/src/main.js
+++ b/src/main.js
@@ -12,11 +12,36 @@ const showFullscreenButton = urlParams.get("show") === "true";
 
 inject();
 
+function parseSeedFromUrl() {
+  const seedParam = urlParams.get("seed");
+  if (seedParam != null && seedParam !== "" && Number.isFinite(Number(seedParam))) {
+    return Number(seedParam) >>> 0;
+  }
+  return null;
+}
+
+function syncSeedToUrl(seed) {
+  const params = new URLSearchParams(window.location.search);
+  params.set("seed", String(seed));
+  const query = params.toString();
+  history.replaceState(null, "", query ? `?${query}` : window.location.pathname);
+}
+
 let currentController = null;
 let userTrees = [];
 let setInteractionBlocked = () => {};
 let updateTreeCounts = () => {};
-let currentSeed = process.env.NODE_ENV === "development" ? 10000 : Date.now();
+let currentSeed = parseSeedFromUrl();
+if (currentSeed == null) {
+  currentSeed = Date.now() >>> 0;
+  syncSeedToUrl(currentSeed);
+}
+
+function regenerateLandscape() {
+  currentSeed = Date.now() >>> 0;
+  syncSeedToUrl(currentSeed);
+  createAndRender({panToOrigin: true});
+}
 
 async function loadUserTrees() {
   try {
@@ -63,6 +88,7 @@ async function bootstrap() {
   ({setInteractionBlocked, updateTreeCounts} = initUI({
     getUserTrees: () => userTrees,
     refreshUserTrees,
+    onRegenerateLandscape: regenerateLandscape,
     onAdd: async (name) => {
       const added = await addLandscapeTree(name);
       userTrees = [added, ...userTrees.filter((tree) => tree.id !== added.id)];

--- a/src/ui.js
+++ b/src/ui.js
@@ -148,7 +148,14 @@ function createTreeActions({onFocus, onDelete}) {
   return actions;
 }
 
-export function initUI({onAdd, onDelete, onFocusTree, getUserTrees, refreshUserTrees}) {
+export function initUI({
+  onAdd,
+  onDelete,
+  onFocusTree,
+  onRegenerateLandscape,
+  getUserTrees,
+  refreshUserTrees,
+}) {
   const toolbar = document.createElement("div");
   toolbar.className = "toolbar";
 
@@ -157,12 +164,30 @@ export function initUI({onAdd, onDelete, onFocusTree, getUserTrees, refreshUserT
   plantButton.className = "toolbar-btn toolbar-btn-primary";
   plantButton.textContent = "+ Plant";
 
+  const remixWrap = document.createElement("div");
+  remixWrap.className = "toolbar-item-with-tooltip";
+
+  const remixButton = document.createElement("button");
+  remixButton.type = "button";
+  remixButton.className = "toolbar-btn toolbar-btn-secondary";
+  remixButton.textContent = "Remix";
+
+  const remixTooltip = document.createElement("div");
+  remixTooltip.className = "toolbar-tooltip";
+  remixTooltip.id = "remix-tooltip";
+  remixTooltip.setAttribute("role", "tooltip");
+  remixTooltip.textContent =
+    "Generate a new random landscape. Mountains change; trees stay the same.";
+  remixButton.setAttribute("aria-describedby", remixTooltip.id);
+
+  remixWrap.append(remixButton, remixTooltip);
+
   const myTreesButton = document.createElement("button");
   myTreesButton.type = "button";
   myTreesButton.className = "toolbar-btn toolbar-btn-secondary";
   myTreesButton.textContent = "My trees";
 
-  toolbar.append(plantButton, myTreesButton);
+  toolbar.append(plantButton, remixWrap, myTreesButton);
   document.body.appendChild(toolbar);
 
   const totalTreesEl = document.createElement("p");
@@ -359,12 +384,14 @@ export function initUI({onAdd, onDelete, onFocusTree, getUserTrees, refreshUserT
   }
 
   plantButton.addEventListener("click", openAddModal);
+  remixButton.addEventListener("click", () => onRegenerateLandscape?.());
   myTreesButton.addEventListener("click", openMyTreesModal);
   updateTreeCounts();
 
   function setInteractionBlocked(blocked) {
     document.body.classList.toggle("interaction-blocked", blocked);
     plantButton.disabled = blocked;
+    remixButton.disabled = blocked;
     myTreesButton.disabled = blocked;
   }
 


### PR DESCRIPTION
## Summary
- Persist landscape seed in the URL (`?seed=…`) on first visit and when remixing, so refresh keeps the same terrain
- Add a **Remix** toolbar button to generate new mountains while community trees stay in place
- Show a custom hover/focus tooltip below the button explaining the behavior

## Test plan
- [x] Open the app with a clean URL and confirm `?seed=…` is added automatically
- [x] Refresh the page and confirm the same landscape is restored
- [x] Click **Remix** and confirm mountains change while trees remain
- [x] Refresh after remix and confirm the new landscape is preserved
- [x] Hover/focus **Remix** and confirm the custom tooltip appears below the button
- [x] Confirm **Remix** is disabled during tree grow/focus animations


Made with [Cursor](https://cursor.com)