### PR TITLE
Use warm paper tone for app background

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       --ink: #1a1a1a;
       --paper: #f6d87b;
       --panel: #fefaf1;
-      --app-bg: #f0e8d8;
+      --app-bg: #f7f3ec;
       --error: #a33;
     }
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       --ink: #1a1a1a;
       --paper: #f6d87b;
       --panel: #fefaf1;
+      --app-bg: #f0e8d8;
       --error: #a33;
     }
 
@@ -26,6 +27,7 @@
       padding: 0;
       font-family: var(--font-serif);
       color: var(--ink);
+      background: var(--app-bg);
       overflow: hidden;
     }
 


### PR DESCRIPTION
## Summary
- Add a dedicated `--app-bg` CSS variable with a light warm paper tone (`#f0e8d8`)
- Apply it to the page `body` background so areas outside the landscape no longer show default white
- Leave landscape gradient and UI panel colors unchanged

## Test plan
- [x] Load the app and confirm the page background behind the landscape is a light warm cream
- [x] Pan and zoom past the landscape edges and verify the exposed area uses the paper tone, not white
- [x] Confirm landscape sky/ground gradients and toolbar/modal styling are unchanged


Made with [Cursor](https://cursor.com)