### PR TITLE
Add PNG and SVG download to plant modal

### DIFF
--- a/src/lib/treeImageExport.js
+++ b/src/lib/treeImageExport.js
@@ -37,6 +37,15 @@ export function createTreeSvg(name, size = EXPORT_SIZE) {
   const text = name.trim() || "Name To Tree";
   const node = tree(text, {...EXPORT_OPTIONS, width: size, height: size}).render();
   node.setAttribute("viewBox", `0 0 ${size} ${size}`);
+
+  const background = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+  background.setAttribute("x", "0");
+  background.setAttribute("y", "0");
+  background.setAttribute("width", String(size));
+  background.setAttribute("height", String(size));
+  background.setAttribute("fill", PAPER);
+  node.insertBefore(background, node.firstChild);
+
   return node;
 }
 
@@ -56,4 +65,35 @@ export async function renderTreePngBlob(name, size = EXPORT_SIZE) {
   context.fillRect(0, 0, image.width, image.height);
   context.drawImage(image, 0, 0, image.width, image.height);
   return canvasToBlob(canvas);
+}
+
+function treeFilename(name) {
+  const base =
+    name
+      .trim()
+      .replace(/[^\w\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .slice(0, 80) || "tree";
+  return base;
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function downloadTreeSvg(name, size = EXPORT_SIZE) {
+  const svg = createTreeSvg(name, size);
+  const serialized = new XMLSerializer().serializeToString(svg);
+  const blob = new Blob([serialized], {type: "image/svg+xml;charset=utf-8"});
+  downloadBlob(blob, `${treeFilename(name)}.svg`);
+}
+
+export async function downloadTreePng(name, size = EXPORT_SIZE) {
+  const blob = await renderTreePngBlob(name, size);
+  downloadBlob(blob, `${treeFilename(name)}.png`);
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -3,7 +3,7 @@ import namesData from "./names.json";
 import {createHowItWorksPanel} from "./howItWorks.js";
 import {getBrowserId} from "./lib/browserId.js";
 import {isSupabaseConfigured} from "./lib/landscapeTreesApi.js";
-import {renderTreePngBlob} from "./lib/treeImageExport.js";
+import {downloadTreePng, downloadTreeSvg, renderTreePngBlob} from "./lib/treeImageExport.js";
 import {uploadTreePng} from "./lib/treeImageUpload.js";
 import {validateName} from "./lib/validateName.js";
 import {createTreePrintQrModal} from "./treePrintQr.js";
@@ -327,14 +327,31 @@ export function initUI({
     submit.textContent = "Plant your tree";
 
     let takeHomeButton = null;
+    let downloadPngButton = null;
+    let downloadSvgButton = null;
+
     if (showMode) {
       takeHomeButton = document.createElement("button");
       takeHomeButton.type = "button";
       takeHomeButton.className = "toolbar-btn toolbar-btn-secondary";
       takeHomeButton.textContent = "Take home";
+    } else {
+      downloadPngButton = document.createElement("button");
+      downloadPngButton.type = "button";
+      downloadPngButton.className = "toolbar-btn toolbar-btn-secondary";
+      downloadPngButton.textContent = "Download PNG";
+
+      downloadSvgButton = document.createElement("button");
+      downloadSvgButton.type = "button";
+      downloadSvgButton.className = "toolbar-btn toolbar-btn-secondary";
+      downloadSvgButton.textContent = "Download SVG";
     }
 
-    actions.append(submit, ...(takeHomeButton ? [takeHomeButton] : []));
+    actions.append(
+      ...(downloadPngButton && downloadSvgButton ? [downloadPngButton, downloadSvgButton] : []),
+      submit,
+      ...(takeHomeButton ? [takeHomeButton] : []),
+    );
     body.append(preview, input, privacy, error, actions);
     modal.dialog.appendChild(body);
     document.body.appendChild(modal.overlay);
@@ -369,6 +386,50 @@ export function initUI({
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") handleSubmit();
     });
+
+    async function handleDownload(button, download) {
+      const validation = validateName(input.value);
+      if (!validation.ok) {
+        error.textContent = validation.error;
+        error.hidden = false;
+        return;
+      }
+
+      error.hidden = true;
+      const originalLabel = button.textContent;
+      button.disabled = true;
+      button.textContent = "Preparing…";
+
+      try {
+        await download(validation.name);
+      } catch (err) {
+        openMessageModal("Could not download", err.message ?? "Please try again.");
+      } finally {
+        button.disabled = false;
+        button.textContent = originalLabel;
+      }
+    }
+
+    if (downloadPngButton && downloadSvgButton) {
+      downloadPngButton.addEventListener("click", () =>
+        handleDownload(downloadPngButton, downloadTreePng),
+      );
+      downloadSvgButton.addEventListener("click", () => {
+        const validation = validateName(input.value);
+        if (!validation.ok) {
+          error.textContent = validation.error;
+          error.hidden = false;
+          return;
+        }
+
+        error.hidden = true;
+        try {
+          downloadTreeSvg(validation.name);
+        } catch (err) {
+          openMessageModal("Could not download", err.message ?? "Please try again.");
+        }
+      });
+    }
 
     if (takeHomeButton) {
       takeHomeButton.addEventListener("click", async () => {


### PR DESCRIPTION
## Summary
- Add **Download PNG** and **Download SVG** buttons in the Plant modal for normal mode, placed next to **Plant your tree**
- Reuse existing tree export helpers with sanitized filenames and the same name validation as planting
- Include the paper background in exported SVGs so they match the preview and PNG output

## Test plan
- [x] Open the app in normal mode (without `?show=true`)
- [x] Click **+ Plant**, enter a name, and confirm **Download PNG** and **Download SVG** appear beside **Plant your tree**
- [x] Download PNG and verify the file has the paper background and correct tree
- [x] Download SVG and verify the file has the paper background (not transparent)
- [x] Confirm show mode still shows **Take home** instead of download buttons
- [x] Confirm invalid names show validation errors instead of downloading


Made with [Cursor](https://cursor.com)