### PR TITLE
Improve mobile view with zoom limits and hidden Remix button

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,6 +453,10 @@
     }
 
     @media (max-width: 640px) {
+      .toolbar-remix-wrap {
+        display: none;
+      }
+
       body.show-mode {
         padding: 12px 0;
       }

--- a/src/render.js
+++ b/src/render.js
@@ -6,6 +6,10 @@ import {tree} from "./tree.js";
 import namesData from "./names.json";
 import {THEME} from "./theme.js";
 
+const MOBILE_MAX_WIDTH = 640;
+const MOBILE_MAX_SCALE = 0.7;
+const MIN_ZOOM_SCALE = 0.15;
+
 const COLORS = {
   background: (d) => ({
     angle: 90,
@@ -307,7 +311,19 @@ export function render({
 } = {}) {
   let communityTreesData = userTrees;
   const centerX = currentX + width / 2;
-  const state = {startX, endX, translateX, scaleX, currentX, offsetX: 0, x0: 0};
+  const isMobile = width <= MOBILE_MAX_WIDTH;
+  const maxScale = isMobile ? MOBILE_MAX_SCALE : 1;
+  const initialScale = maxScale;
+  const initialTranslateX = width / 2 - centerX * initialScale;
+  const state = {
+    startX,
+    endX,
+    translateX: isMobile ? initialTranslateX : translateX,
+    scaleX: isMobile ? initialScale : scaleX,
+    currentX,
+    offsetX: 0,
+    x0: 0,
+  };
   let centerTreeY = height * 0.75;
   let interactionLocked = false;
   let pendingGrowDbId = null;
@@ -325,12 +341,12 @@ export function render({
   }
 
   function centerTransform() {
-    const k = 1;
+    const k = maxScale;
     const tx = width / 2 - centerX * k;
     return d3.zoomIdentity.translate(tx, 0).scale(k);
   }
 
-  function transformForWorldX(worldX, k = 1) {
+  function transformForWorldX(worldX, k = maxScale) {
     return d3.zoomIdentity.translate(width / 2 - worldX * k, 0).scale(k);
   }
 
@@ -416,10 +432,11 @@ export function render({
     });
 
   const mountainsGroup = transformGroup.append("g").attr("class", "mountains-group");
+  const treesGroup = transformGroup.append("g").attr("class", "trees-group");
 
   const zoomBehavior = d3
     .zoom()
-    .scaleExtent([0.15, 1])
+    .scaleExtent([MIN_ZOOM_SCALE, maxScale])
     .on("zoom", (event) => {
       const {x, k} = event.transform;
       state.scaleX = k;
@@ -429,10 +446,10 @@ export function render({
     });
 
   svg.call(zoomBehavior);
-
-  const treesGroup = transformGroup.append("g").attr("class", "trees-group");
-
-  update();
+  svg.call(
+    zoomBehavior.transform,
+    d3.zoomIdentity.translate(state.translateX, 0).scale(state.scaleX),
+  );
 
   function maybeLoad() {
     const rect = bgRect.node();
@@ -592,7 +609,7 @@ export function render({
     panToTreeAnimated(dbId, duration = 700) {
       const worldX = getWorldXForDbId(dbId);
       if (worldX === null) return Promise.resolve();
-      return panToTransformAnimated(transformForWorldX(worldX, 1), duration);
+      return panToTransformAnimated(transformForWorldX(worldX), duration);
     },
     isInteractionLocked() {
       return interactionLocked;

--- a/src/ui.js
+++ b/src/ui.js
@@ -195,7 +195,7 @@ export function initUI({
   }
 
   const remixWrap = document.createElement("div");
-  remixWrap.className = "toolbar-item-with-tooltip";
+  remixWrap.className = "toolbar-item-with-tooltip toolbar-remix-wrap";
 
   const remixButton = document.createElement("button");
   remixButton.type = "button";


### PR DESCRIPTION
## Summary
- Hide the Remix toolbar button on viewports ≤640px to simplify the mobile toolbar.
- Start the landscape at 0.7 zoom on mobile and cap max zoom at 0.7 so pinch/scroll cannot zoom in further.
- Fix zoom initialization order so `treesGroup` exists before the initial transform runs.

## Test plan
- [x] Open the app on a viewport ≤640px (or use devtools mobile emulation)
- [x] Confirm Remix is hidden; + Plant and My trees remain visible
- [x] Confirm the landscape loads zoomed out at 0.7 and is centered
- [x] Pinch/scroll to zoom in and verify it stops at 0.7
- [x] Pinch/scroll to zoom out and verify zoom-out still works
- [x] Resize to desktop width and confirm Remix returns and zoom max is 1.0
- [x] Test pan-to-tree and remix/regenerate flows on desktop to ensure no regressions


Made with [Cursor](https://cursor.com)