### PR TITLE
Re-render landscape on focus instead of panning

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import {render} from "./render.js";
+import {rankIndexForDbId, render} from "./render.js";
 import {initShowModeQr} from "./showModeQr.js";
 import {initUI} from "./ui.js";
 import {
@@ -38,6 +38,7 @@ let userTrees = [];
 let setInteractionBlocked = () => {};
 let updateTreeCounts = () => {};
 let currentSeed = parseSeedFromUrl();
+let centerRankIndex = 0;
 if (currentSeed == null) {
   currentSeed = Date.now() >>> 0;
   syncSeedToUrl(currentSeed);
@@ -45,8 +46,19 @@ if (currentSeed == null) {
 
 function regenerateLandscape() {
   currentSeed = Date.now() >>> 0;
+  centerRankIndex = 0;
   syncSeedToUrl(currentSeed);
   createAndRender({panToOrigin: true});
+}
+
+function focusRank(rankIndex) {
+  if (rankIndex < 0) return;
+  centerRankIndex = rankIndex;
+  createAndRender();
+}
+
+function focusTree(dbId) {
+  focusRank(rankIndexForDbId(userTrees, dbId));
 }
 
 async function loadUserTrees() {
@@ -69,6 +81,7 @@ function createAndRender({panToOrigin = false} = {}) {
     width: window.innerWidth,
     seed: currentSeed,
     userTrees,
+    centerRankIndex,
   });
 
   container.appendChild(currentController.node);
@@ -100,12 +113,7 @@ async function bootstrap() {
       const added = await addLandscapeTree(name);
       userTrees = [added, ...userTrees.filter((tree) => tree.id !== added.id)];
       updateTreeCounts();
-      if (currentController) {
-        setInteractionBlocked(true);
-        void currentController.setUserTreesAndGrow(userTrees, added.id).finally(() => {
-          setInteractionBlocked(false);
-        });
-      }
+      focusTree(added.id);
     },
     onDelete: async (id) => {
       await deleteLandscapeTree(id);
@@ -115,23 +123,11 @@ async function bootstrap() {
         currentController.setUserTrees(userTrees);
       }
     },
-    onFocusTree: async (id) => {
-      if (!currentController) return;
-      setInteractionBlocked(true);
-      try {
-        await currentController.panToTreeAnimated(id);
-      } finally {
-        setInteractionBlocked(false);
-      }
+    onFocusTree: (id) => {
+      focusTree(id);
     },
-    onFocusRank: async (rankIndex) => {
-      if (!currentController) return;
-      setInteractionBlocked(true);
-      try {
-        await currentController.panToRankAnimated(rankIndex);
-      } finally {
-        setInteractionBlocked(false);
-      }
+    onFocusRank: (rankIndex) => {
+      focusRank(rankIndex);
     },
   }));
 }

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,4 @@
 import * as d3 from "d3";
-import {animateTreeGrow, prepareTreeForGrow} from "./animateTree.js";
 import {randomNoise} from "./noise.js";
 import {applyGradient} from "./gradient.js";
 import {tree} from "./tree.js";
@@ -271,17 +270,18 @@ function placeTreeOnMountain({x, name, id, height, mountains, scaleWidth, source
   };
 }
 
-function placeMergedTrees({userTrees, startX, endX, seed, height, mountains, centerX}) {
+function placeMergedTrees({userTrees, startX, endX, seed, height, mountains, centerX, centerRankIndex = 0}) {
   const ranks = buildMergedRanks(userTrees);
   if (ranks.length === 0) return [];
 
   const slotX = createSlotX(seed, centerX);
   const scaleWidth = createTreeScaler();
   const slots = slotsInRange(startX, endX, seed, centerX);
+  const n = ranks.length;
 
   return slots
     .map((slot) => {
-      const rank = ranks[slot % ranks.length];
+      const rank = ranks[((centerRankIndex + slot) % n + n) % n];
       return placeTreeOnMountain({
         x: slotX(slot),
         name: rank.name,
@@ -298,6 +298,11 @@ function placeMergedTrees({userTrees, startX, endX, seed, height, mountains, cen
     .filter(Boolean);
 }
 
+export function rankIndexForDbId(userTrees, dbId) {
+  const ranks = buildMergedRanks(userTrees);
+  return ranks.findIndex((rank) => rank.dbId === dbId);
+}
+
 export function render({
   width = 1000,
   height = 540,
@@ -308,6 +313,7 @@ export function render({
   scaleX = 1,
   seed = 10000,
   userTrees = [],
+  centerRankIndex = 0,
 } = {}) {
   let communityTreesData = userTrees;
   const centerX = currentX + width / 2;
@@ -325,87 +331,11 @@ export function render({
     x0: 0,
   };
   let centerTreeY = height * 0.75;
-  let interactionLocked = false;
-  let pendingGrowDbId = null;
-  let growCompleteCallback = null;
-  let growStarted = false;
-
-  const defaultZoomFilter = (event) =>
-    (!event.ctrlKey || event.type === "wheel") && !event.button;
-
-  function setInteractionLocked(locked) {
-    interactionLocked = locked;
-    zoomBehavior.filter(locked ? () => false : defaultZoomFilter);
-    svg.style("pointer-events", locked ? "none" : "auto");
-    svg.style("cursor", locked ? "default" : "grab");
-  }
 
   function centerTransform() {
     const k = maxScale;
     const tx = width / 2 - centerX * k;
     return d3.zoomIdentity.translate(tx, 0).scale(k);
-  }
-
-  function transformForWorldX(worldX, k = maxScale) {
-    return d3.zoomIdentity.translate(width / 2 - worldX * k, 0).scale(k);
-  }
-
-  function isAtTransform(target) {
-    const current = d3.zoomTransform(svg.node());
-    const epsilon = 0.5;
-    return (
-      Math.abs(current.x - target.x) < epsilon &&
-      Math.abs(current.y - target.y) < epsilon &&
-      Math.abs(current.k - target.k) < 0.001
-    );
-  }
-
-  function getWorldXForRank(rankIndex) {
-    const ranks = buildMergedRanks(communityTreesData);
-    if (rankIndex < 0 || rankIndex >= ranks.length) return null;
-
-    const slotX = createSlotX(seed, centerX);
-    const viewCenterX = (width / 2 - state.translateX) / state.scaleX;
-    const n = ranks.length;
-    const originX = slotX(rankIndex);
-    const approxGap = (GAP_MIN + GAP_MAX) / 2;
-    const deltaSlots = Math.ceil(Math.abs(viewCenterX - originX) / approxGap / n) + 2;
-
-    let bestSlot = rankIndex;
-    let bestDist = Infinity;
-    for (let k = -deltaSlots; k <= deltaSlots; k++) {
-      const slot = rankIndex + k * n;
-      if (slot < 0) continue;
-      const x = slotX(slot);
-      const dist = Math.abs(x - viewCenterX);
-      if (dist < bestDist) {
-        bestDist = dist;
-        bestSlot = slot;
-      }
-    }
-
-    return slotX(bestSlot);
-  }
-
-  function getWorldXForDbId(dbId) {
-    const ranks = buildMergedRanks(communityTreesData);
-    const rankIndex = ranks.findIndex((rank) => rank.dbId === dbId);
-    if (rankIndex < 0) return null;
-    return getWorldXForRank(rankIndex);
-  }
-
-  function panToTransformAnimated(target, duration = 700) {
-    if (isAtTransform(target)) {
-      return Promise.resolve();
-    }
-    return new Promise((resolve) => {
-      svg
-        .transition()
-        .duration(duration)
-        .ease(d3.easeCubicInOut)
-        .call(zoomBehavior.transform, target)
-        .on("end", resolve);
-    });
   }
 
   const line = d3
@@ -443,6 +373,7 @@ export function render({
   const zoomBehavior = d3
     .zoom()
     .scaleExtent([MIN_ZOOM_SCALE, maxScale])
+    .filter((event) => (!event.ctrlKey || event.type === "wheel") && !event.button)
     .on("zoom", (event) => {
       const {x, k} = event.transform;
       state.scaleX = k;
@@ -496,6 +427,7 @@ export function render({
       height,
       mountains: closeMountains,
       centerX,
+      centerRankIndex,
     });
 
     const centerTree = trees.find((tree) => tree.slot === 0);
@@ -531,9 +463,6 @@ export function render({
     // Update trees
     const treeGroups = treesGroup.selectAll("g.tree-group").data(trees, (d) => d.id);
 
-    const growDbId = pendingGrowDbId;
-    pendingGrowDbId = null;
-
     treeGroups
       .enter()
       .append("g")
@@ -549,17 +478,6 @@ export function render({
           strokeWidth: 1,
         }).render();
         d3.select(group).append(() => treeSvg);
-
-        if (growDbId && d.slot === 0 && d.dbId === growDbId) {
-          growStarted = true;
-          setInteractionLocked(true);
-          prepareTreeForGrow(group);
-          animateTreeGrow(group).then(() => {
-              setInteractionLocked(false);
-              growCompleteCallback?.();
-              growCompleteCallback = null;
-            });
-        }
       })
       .merge(treeGroups)
       .attr("transform", (d) => {
@@ -579,51 +497,8 @@ export function render({
       communityTreesData = trees;
       update();
     },
-    setUserTreesAndGrow(trees, growDbId) {
-      return new Promise((resolve) => {
-        if (!growDbId) {
-          communityTreesData = trees;
-          update();
-          resolve();
-          return;
-        }
-
-        growStarted = false;
-        growCompleteCallback = resolve;
-        setInteractionLocked(true);
-
-        this.panToCenterAnimated().then(() => {
-          pendingGrowDbId = growDbId;
-          communityTreesData = trees;
-          update();
-          requestAnimationFrame(() => {
-            if (!growStarted) {
-              setInteractionLocked(false);
-              growCompleteCallback?.();
-              growCompleteCallback = null;
-            }
-          });
-        });
-      });
-    },
     panToCenter() {
       svg.call(zoomBehavior.transform, centerTransform());
-    },
-    panToCenterAnimated(duration = 700) {
-      return panToTransformAnimated(centerTransform(), duration);
-    },
-    panToTreeAnimated(dbId, duration = 700) {
-      const worldX = getWorldXForDbId(dbId);
-      if (worldX === null) return Promise.resolve();
-      return panToTransformAnimated(transformForWorldX(worldX), duration);
-    },
-    panToRankAnimated(rankIndex, duration = 700) {
-      const worldX = getWorldXForRank(rankIndex);
-      if (worldX === null) return Promise.resolve();
-      return panToTransformAnimated(transformForWorldX(worldX), duration);
-    },
-    isInteractionLocked() {
-      return interactionLocked;
     },
   };
 }


### PR DESCRIPTION
## Summary
- Unify plant, search, and My trees focus by destroying the current landscape and re-rendering with the selected tree centered at slot 0 via `centerRankIndex`
- Fix search focus on distant archive trees (e.g. Bairui Su) showing a blank view caused by jumping the camera outside the loaded range
- Remove focus pan animations and the plant grow animation path for a lighter, instant focus experience

## Test plan
- [x] Run `npm run dev` and plant a new tree — landscape re-renders with the new tree centered
- [x] Open **My trees**, focus a community tree — landscape re-renders with that tree centered
- [x] Open **Search**, find an archive tree (e.g. Bairui Su), focus — landscape re-renders correctly (no blank view)
- [x] Click **Remix** — landscape resets to default center (rank 0) with a new seed
- [x] Pan and zoom after focus still work as before
- [x] Run `npm run build` successfully


Made with [Cursor](https://cursor.com)