### PR TITLE
Fix landscape total tree count capped at 1165

### DIFF
--- a/src/lib/landscapeTreesApi.js
+++ b/src/lib/landscapeTreesApi.js
@@ -24,6 +24,18 @@ export async function fetchLandscapeTrees() {
   return (data ?? []).map(rowToTree);
 }
 
+export async function fetchLandscapeTreeCount() {
+  const supabase = getSupabase();
+  if (!supabase) return 0;
+
+  const {count, error} = await supabase
+    .from("landscape_trees")
+    .select("*", {count: "exact", head: true});
+
+  if (error) throw error;
+  return count ?? 0;
+}
+
 export async function addLandscapeTree(name) {
   const supabase = getSupabase();
   if (!supabase) {

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import {initUI} from "./ui.js";
 import {
   addLandscapeTree,
   deleteLandscapeTree,
+  fetchLandscapeTreeCount,
   fetchLandscapeTrees,
 } from "./lib/landscapeTreesApi.js";
 import {inject} from "@vercel/analytics";
@@ -35,6 +36,7 @@ function syncSeedToUrl(seed) {
 
 let currentController = null;
 let userTrees = [];
+let communityTreeCount = 0;
 let setInteractionBlocked = () => {};
 let updateTreeCounts = () => {};
 let currentSeed = parseSeedFromUrl();
@@ -63,10 +65,16 @@ function focusTree(dbId) {
 
 async function loadUserTrees() {
   try {
-    userTrees = await fetchLandscapeTrees();
+    const [trees, count] = await Promise.all([
+      fetchLandscapeTrees(),
+      fetchLandscapeTreeCount(),
+    ]);
+    userTrees = trees;
+    communityTreeCount = count;
   } catch (error) {
     console.error("Failed to load community trees:", error);
     userTrees = [];
+    communityTreeCount = 0;
   }
   return userTrees;
 }
@@ -107,17 +115,20 @@ async function bootstrap() {
   ({setInteractionBlocked, updateTreeCounts} = initUI({
     showMode,
     getUserTrees: () => userTrees,
+    getCommunityTreeCount: () => communityTreeCount,
     refreshUserTrees,
     onRegenerateLandscape: regenerateLandscape,
     onAdd: async (name) => {
       const added = await addLandscapeTree(name);
       userTrees = [added, ...userTrees.filter((tree) => tree.id !== added.id)];
+      communityTreeCount += 1;
       updateTreeCounts();
       focusTree(added.id);
     },
     onDelete: async (id) => {
       await deleteLandscapeTree(id);
       userTrees = userTrees.filter((tree) => tree.id !== id);
+      communityTreeCount = Math.max(0, communityTreeCount - 1);
       updateTreeCounts();
       if (currentController) {
         currentController.setUserTrees(userTrees);

--- a/src/ui.js
+++ b/src/ui.js
@@ -188,6 +188,7 @@ export function initUI({
   onFocusRank,
   onRegenerateLandscape,
   getUserTrees,
+  getCommunityTreeCount,
   refreshUserTrees,
 }) {
   const toolbar = document.createElement("div");
@@ -263,7 +264,7 @@ export function initUI({
   }
 
   function totalTreeCount() {
-    return getUserTrees().length + namesData.length;
+    return getCommunityTreeCount() + namesData.length;
   }
 
   function updateTreeCounts() {


### PR DESCRIPTION
## Summary
- Add `fetchLandscapeTreeCount()` using Supabase's exact count query, which is not limited by the 1000-row fetch cap.
- Track `communityTreeCount` in `main.js` on load, refresh, plant, and delete.
- Show the true total in the footer as archive names (`names.json`) plus all community trees in the database.

## Test plan
- [x] Open the live app and confirm the footer total is above 1,165 when the database has more than 1,000 community trees
- [x] Plant a new tree and confirm the total increments by 1
- [x] Delete one of your trees and confirm the total decrements by 1
- [x] Reload the page and confirm the total matches the database count


Made with [Cursor](https://cursor.com)