### PR TITLE
Paginate community tree fetch to load full landscape.

### DIFF
--- a/src/lib/landscapeTreesApi.js
+++ b/src/lib/landscapeTreesApi.js
@@ -11,29 +11,31 @@ function rowToTree(row) {
   };
 }
 
+const PAGE_SIZE = 1000;
+
 export async function fetchLandscapeTrees() {
   const supabase = getSupabase();
   if (!supabase) return [];
 
-  const {data, error} = await supabase
-    .from("landscape_trees")
-    .select("id, name, browser_id, created_at")
-    .order("created_at", {ascending: false});
+  const trees = [];
+  let from = 0;
 
-  if (error) throw error;
-  return (data ?? []).map(rowToTree);
-}
+  while (true) {
+    const {data, error} = await supabase
+      .from("landscape_trees")
+      .select("id, name, browser_id, created_at")
+      .order("created_at", {ascending: false})
+      .range(from, from + PAGE_SIZE - 1);
 
-export async function fetchLandscapeTreeCount() {
-  const supabase = getSupabase();
-  if (!supabase) return 0;
+    if (error) throw error;
 
-  const {count, error} = await supabase
-    .from("landscape_trees")
-    .select("*", {count: "exact", head: true});
+    const page = data ?? [];
+    trees.push(...page.map(rowToTree));
+    if (page.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
 
-  if (error) throw error;
-  return count ?? 0;
+  return trees;
 }
 
 export async function addLandscapeTree(name) {

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,6 @@ import {initUI} from "./ui.js";
 import {
   addLandscapeTree,
   deleteLandscapeTree,
-  fetchLandscapeTreeCount,
   fetchLandscapeTrees,
 } from "./lib/landscapeTreesApi.js";
 import {inject} from "@vercel/analytics";
@@ -36,7 +35,6 @@ function syncSeedToUrl(seed) {
 
 let currentController = null;
 let userTrees = [];
-let communityTreeCount = 0;
 let setInteractionBlocked = () => {};
 let updateTreeCounts = () => {};
 let currentSeed = parseSeedFromUrl();
@@ -65,16 +63,10 @@ function focusTree(dbId) {
 
 async function loadUserTrees() {
   try {
-    const [trees, count] = await Promise.all([
-      fetchLandscapeTrees(),
-      fetchLandscapeTreeCount(),
-    ]);
-    userTrees = trees;
-    communityTreeCount = count;
+    userTrees = await fetchLandscapeTrees();
   } catch (error) {
     console.error("Failed to load community trees:", error);
     userTrees = [];
-    communityTreeCount = 0;
   }
   return userTrees;
 }
@@ -115,20 +107,18 @@ async function bootstrap() {
   ({setInteractionBlocked, updateTreeCounts} = initUI({
     showMode,
     getUserTrees: () => userTrees,
-    getCommunityTreeCount: () => communityTreeCount,
+    getCommunityTreeCount: () => userTrees.length,
     refreshUserTrees,
     onRegenerateLandscape: regenerateLandscape,
     onAdd: async (name) => {
       const added = await addLandscapeTree(name);
       userTrees = [added, ...userTrees.filter((tree) => tree.id !== added.id)];
-      communityTreeCount += 1;
       updateTreeCounts();
       focusTree(added.id);
     },
     onDelete: async (id) => {
       await deleteLandscapeTree(id);
       userTrees = userTrees.filter((tree) => tree.id !== id);
-      communityTreeCount = Math.max(0, communityTreeCount - 1);
       updateTreeCounts();
       if (currentController) {
         currentController.setUserTrees(userTrees);


### PR DESCRIPTION
## Summary

Follow-up to #36. Supabase caps each query at 1000 rows, so the app was only loading the 1000 newest community trees even though the database has ~1400+. That broke more than the footer count:

- **Total count** stuck at 1165 (1000 community + 165 archive) when using loaded row count
- **My trees** missing older trees that fell outside the newest-1000 window
- **Focus** could not find trees that were not in the loaded set
- **Neighbors / loop period** were wrong because the merged rank list was incomplete

This PR paginates `fetchLandscapeTrees()` in 1000-row pages until all rows are loaded. The footer total now derives from `userTrees.length + names.json.length`, so one full fetch keeps counts, rendering, My trees, and focus in sync.

## Test plan

- [x] Load the live app and confirm the footer total is above 1,165 (~1,565 with current data)
- [x] Open **My trees** and confirm older planted trees appear
- [x] Focus an older tree and confirm it centers with plausible neighbors on either side
- [x] Plant a new tree and confirm the total increments by 1
- [x] Delete one of your trees and confirm the total decrements by 1
- [x] Reload the page and confirm the total matches the database