### PR TITLE
Fix plant modal overflow on small mobile viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,25 +508,6 @@
         height: 64px;
       }
 
-      body.show-mode .modal-group:has(.modal-dialog-plant-show) {
-        width: min(100%, calc(100vw - 24px));
-      }
-
-      body.show-mode .modal-dialog-plant-show .modal-title {
-        font-size: 19px;
-      }
-
-      body.show-mode .modal-dialog-plant-show .modal-input {
-        font-size: 16px;
-        padding: 12px 14px;
-      }
-
-      body.show-mode .modal-group-with-help:has(.modal-dialog-plant-show) .modal-dialog-plant-show,
-      body.show-mode .modal-group-with-help:has(.modal-dialog-plant-show) .modal-help-dialog {
-        width: 100%;
-        flex: 1 1 auto;
-      }
-
       .modal-overlay:has(.modal-dialog-plant) {
         padding: 12px;
         padding-top: max(12px, env(safe-area-inset-top));
@@ -538,11 +519,8 @@
 
       .modal-group:has(.modal-dialog-plant) {
         width: min(100%, calc(100vw - 24px));
+        max-width: calc(100vw - 24px);
         margin: auto 0;
-      }
-
-      .modal-dialog-plant {
-        max-height: none;
       }
 
       .modal-dialog-plant .modal-header {
@@ -591,30 +569,6 @@
         width: 100%;
         justify-content: center;
         text-align: center;
-      }
-
-      body.show-mode .modal-dialog-plant-show .modal-header {
-        padding: 12px 14px 0;
-      }
-
-      body.show-mode .modal-dialog-plant-show .modal-body {
-        padding: 12px 14px 16px;
-      }
-
-      body.show-mode .modal-dialog-plant-show .modal-preview {
-        width: min(100%, 220px);
-        margin-inline: auto;
-        margin-bottom: 10px;
-      }
-
-      body.show-mode .modal-dialog-plant-show .modal-privacy {
-        font-size: 12px;
-        margin-bottom: 10px;
-      }
-
-      body.show-mode .modal-dialog-plant-show .modal-actions .toolbar-btn {
-        font-size: 15px;
-        padding: 12px 16px;
       }
     }
 
@@ -1053,6 +1007,55 @@
 
     body.show-mode .modal-group-with-help:has(.modal-dialog-plant-show) .modal-help-dialog {
       width: 420px;
+    }
+
+    @media (max-width: 640px) {
+      .modal-dialog.modal-dialog-plant {
+        max-height: none;
+      }
+
+      body.show-mode .modal-group:has(.modal-dialog-plant-show) {
+        width: min(100%, calc(100vw - 24px));
+        max-width: calc(100vw - 24px);
+      }
+
+      body.show-mode .modal-group-with-help:has(.modal-dialog-plant-show) .modal-dialog-plant-show,
+      body.show-mode .modal-group-with-help:has(.modal-dialog-plant-show) .modal-help-dialog {
+        width: 100%;
+        flex: 1 1 auto;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-header {
+        padding: 12px 14px 0;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-title {
+        font-size: 19px;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-body {
+        padding: 12px 14px 16px;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-preview {
+        margin-bottom: 10px;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-input {
+        font-size: 16px;
+        padding: 12px 14px;
+        margin-bottom: 8px;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-privacy {
+        font-size: 12px;
+        margin-bottom: 10px;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-actions .toolbar-btn {
+        font-size: 15px;
+        padding: 12px 16px;
+      }
     }
 
     .modal-group:has(.modal-dialog-my-trees) {

--- a/index.html
+++ b/index.html
@@ -526,6 +526,103 @@
         width: 100%;
         flex: 1 1 auto;
       }
+
+      .modal-overlay:has(.modal-dialog-plant) {
+        padding: 12px;
+        padding-top: max(12px, env(safe-area-inset-top));
+        padding-bottom: max(12px, env(safe-area-inset-bottom));
+        align-items: flex-start;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      .modal-group:has(.modal-dialog-plant) {
+        width: min(100%, calc(100vw - 24px));
+        margin: auto 0;
+      }
+
+      .modal-dialog-plant {
+        max-height: none;
+      }
+
+      .modal-dialog-plant .modal-header {
+        padding: 12px 14px 0;
+      }
+
+      .modal-dialog-plant .modal-body {
+        padding: 12px 14px 16px;
+      }
+
+      .modal-dialog-plant .modal-preview {
+        width: min(100%, 220px);
+        margin-inline: auto;
+        margin-bottom: 10px;
+      }
+
+      .modal-dialog-plant .modal-input {
+        font-size: 16px;
+        padding: 10px 12px;
+        margin-bottom: 8px;
+      }
+
+      .modal-dialog-plant .modal-privacy {
+        font-size: 11px;
+        line-height: 1.4;
+        margin-bottom: 10px;
+      }
+
+      .modal-dialog-plant .modal-actions {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+
+      .modal-dialog-plant .modal-actions .toolbar-btn-primary {
+        grid-column: 1 / -1;
+      }
+
+      .modal-dialog-plant .modal-actions .toolbar-btn:nth-child(2):last-child {
+        grid-column: 1 / -1;
+      }
+
+      .modal-dialog-plant .modal-actions .toolbar-btn {
+        font-size: 13px;
+        padding: 10px 12px;
+        width: 100%;
+        justify-content: center;
+        text-align: center;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-header {
+        padding: 12px 14px 0;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-body {
+        padding: 12px 14px 16px;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-preview {
+        width: min(100%, 220px);
+        margin-inline: auto;
+        margin-bottom: 10px;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-privacy {
+        font-size: 12px;
+        margin-bottom: 10px;
+      }
+
+      body.show-mode .modal-dialog-plant-show .modal-actions .toolbar-btn {
+        font-size: 15px;
+        padding: 12px 16px;
+      }
+    }
+
+    @media (max-width: 640px) and (max-height: 740px) {
+      .modal-dialog-plant .modal-preview,
+      body.show-mode .modal-dialog-plant-show .modal-preview {
+        width: min(100%, 180px);
+      }
     }
 
     .modal-overlay {
@@ -556,7 +653,7 @@
 
     .modal-dialog {
       width: 100%;
-      max-height: 90vh;
+      max-height: min(90vh, 90dvh);
       overflow: auto;
       background: var(--panel);
       border: 1.5px solid var(--ink);

--- a/src/ui.js
+++ b/src/ui.js
@@ -329,6 +329,7 @@ export function initUI({
       onClose: closeModal,
       getHelpSample: () => input.value,
     });
+    modal.dialog.classList.add("modal-dialog-plant");
     if (showMode) {
       modal.dialog.classList.add("modal-dialog-plant-show");
     }


### PR DESCRIPTION
## Summary
- Cap the plant modal tree preview at 220px on mobile (180px on short screens) so a full-width square no longer pushes content off-screen
- Tighten mobile padding, privacy text, and action button layout for the plant modal
- Add a `modal-dialog-plant` class and use `dvh` for modal max-height to improve mobile Safari behavior

## Test plan
- [x] Open the site on iPhone 11 (or 414×714 viewport) and tap **+ Plant**
- [x] Confirm the preview is smaller and all buttons (Download PNG, Download SVG, Plant your tree) are visible without scrolling
- [x] Verify show-mode plant modal still looks correct on mobile
- [x] Confirm desktop plant modal layout is unchanged


Made with [Cursor](https://cursor.com)