### PR TITLE
Restore grow animation for newly planted trees

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import {rankIndexForDbId, render} from "./render.js";
+import {prepareTreeForGrow, animateTreeGrow} from "./animateTree.js";
 import {initShowModeQr} from "./showModeQr.js";
 import {initUI} from "./ui.js";
 import {
@@ -115,6 +116,11 @@ async function bootstrap() {
       userTrees = [added, ...userTrees.filter((tree) => tree.id !== added.id)];
       updateTreeCounts();
       focusTree(added.id);
+      const groupEl = currentController.node.querySelector(`[data-db-id="${added.id}"]`);
+      if (groupEl) {
+        prepareTreeForGrow(groupEl);
+        animateTreeGrow(groupEl);
+      }
     },
     onDelete: async (id) => {
       await deleteLandscapeTree(id);

--- a/src/render.js
+++ b/src/render.js
@@ -499,6 +499,7 @@ export function render({
       .enter()
       .append("g")
       .attr("class", "tree-group")
+      .attr("data-db-id", (d) => d.dbId ?? null)
       .each(function (d) {
         const group = this;
         const treeSvg = tree(d.name, {

--- a/src/ui.js
+++ b/src/ui.js
@@ -239,15 +239,12 @@ export function initUI({
   myTreesButton.className = "toolbar-btn toolbar-btn-secondary";
   myTreesButton.textContent = "My trees";
 
-  let searchButton = null;
-  if (import.meta.env.DEV) {
-    searchButton = document.createElement("button");
-    searchButton.type = "button";
-    searchButton.className = "toolbar-btn toolbar-btn-secondary toolbar-btn-dev";
-    searchButton.textContent = "Search";
-  }
+  const searchButton = document.createElement("button");
+  searchButton.type = "button";
+  searchButton.className = "toolbar-btn toolbar-btn-secondary";
+  searchButton.textContent = "Search";
 
-  toolbar.append(plantWrap, remixWrap, myTreesButton, ...(searchButton ? [searchButton] : []));
+  toolbar.append(plantWrap, remixWrap, myTreesButton, searchButton);
   document.body.appendChild(toolbar);
 
   const totalTreesEl = document.createElement("p");
@@ -658,7 +655,7 @@ export function initUI({
   function openSearchModal() {
     closeModal();
 
-    const modal = createModal({title: "Search trees (dev)", onClose: closeModal});
+    const modal = createModal({title: "Search trees", onClose: closeModal});
     modal.dialog.classList.add("modal-dialog-search");
     activeModal = modal;
 
@@ -697,7 +694,7 @@ export function initUI({
     plantButton.disabled = blocked;
     remixButton.disabled = blocked;
     myTreesButton.disabled = blocked;
-    if (searchButton) searchButton.disabled = blocked;
+    searchButton.disabled = blocked;
   }
 
   return {closeModal, setInteractionBlocked, updateTreeCounts};

--- a/src/ui.js
+++ b/src/ui.js
@@ -68,12 +68,14 @@ function createModal({title, onClose, getHelpSample}) {
   const headerActions = document.createElement("div");
   headerActions.className = "modal-header-actions";
 
-  const helpButton = document.createElement("button");
-  helpButton.type = "button";
-  helpButton.className = "modal-help";
-  helpButton.setAttribute("aria-label", "How it works");
-  helpButton.setAttribute("aria-pressed", "false");
-  helpButton.textContent = "?";
+  const helpButton = getHelpSample ? document.createElement("button") : null;
+  if (helpButton) {
+    helpButton.type = "button";
+    helpButton.className = "modal-help";
+    helpButton.setAttribute("aria-label", "How it works");
+    helpButton.setAttribute("aria-pressed", "false");
+    helpButton.textContent = "?";
+  }
 
   const closeButton = document.createElement("button");
   closeButton.type = "button";
@@ -82,7 +84,7 @@ function createModal({title, onClose, getHelpSample}) {
   closeButton.textContent = "×";
   closeButton.addEventListener("click", onClose);
 
-  headerActions.append(helpButton, closeButton);
+  headerActions.append(...(helpButton ? [helpButton] : []), closeButton);
   header.append(heading, headerActions);
   dialog.appendChild(header);
   group.appendChild(dialog);
@@ -93,7 +95,7 @@ function createModal({title, onClose, getHelpSample}) {
     helpPanel.remove();
     helpPanel = null;
     group.classList.remove("modal-group-with-help");
-    helpButton.setAttribute("aria-pressed", "false");
+    helpButton?.setAttribute("aria-pressed", "false");
   }
 
   function openHelp() {
@@ -104,10 +106,10 @@ function createModal({title, onClose, getHelpSample}) {
     });
     group.classList.add("modal-group-with-help");
     group.appendChild(helpPanel);
-    helpButton.setAttribute("aria-pressed", "true");
+    helpButton?.setAttribute("aria-pressed", "true");
   }
 
-  helpButton.addEventListener("click", (event) => {
+  helpButton?.addEventListener("click", (event) => {
     event.stopPropagation();
     if (helpPanel) closeHelp();
     else openHelp();

--- a/src/ui.js
+++ b/src/ui.js
@@ -241,12 +241,15 @@ export function initUI({
   myTreesButton.className = "toolbar-btn toolbar-btn-secondary";
   myTreesButton.textContent = "My trees";
 
-  const searchButton = document.createElement("button");
-  searchButton.type = "button";
-  searchButton.className = "toolbar-btn toolbar-btn-secondary";
-  searchButton.textContent = "Search";
+  let searchButton = null;
+  if (import.meta.env.DEV) {
+    searchButton = document.createElement("button");
+    searchButton.type = "button";
+    searchButton.className = "toolbar-btn toolbar-btn-secondary";
+    searchButton.textContent = "Search";
+  }
 
-  toolbar.append(plantWrap, remixWrap, myTreesButton, searchButton);
+  toolbar.append(plantWrap, remixWrap, myTreesButton, ...(searchButton ? [searchButton] : []));
   document.body.appendChild(toolbar);
 
   const totalTreesEl = document.createElement("p");
@@ -696,7 +699,7 @@ export function initUI({
     plantButton.disabled = blocked;
     remixButton.disabled = blocked;
     myTreesButton.disabled = blocked;
-    searchButton.disabled = blocked;
+    if (searchButton) searchButton.disabled = blocked;
   }
 
   return {closeModal, setInteractionBlocked, updateTreeCounts};


### PR DESCRIPTION
## Summary

- **Restore grow animation for newly planted trees** — the branch-draw + flower/name-fade-in animation was lost in #34 when `onAdd` switched to `createAndRender()`, which recreates the whole SVG so D3's enter selection always contains every tree. Fix: tag each tree group with `data-db-id` in `render.js`, then after `focusTree()` appends the SVG to the DOM, look up the new tree's group element and drive `prepareTreeForGrow` + `animateTreeGrow` in `main.js`. `animateTree.js` is untouched.
- **Hide `?` help button when no help content is provided** — `createModal` now only renders the help button when `getHelpSample` is passed, avoiding a non-functional button in modals that don't have help content.

## Test plan

- [x] Plant a new tree — branches draw in level-by-level, then flowers and the name fade in
- [x] Other trees on the landscape appear instantly (no animation on pre-existing trees)
- [x] Modals with help content (plant, my trees) still show the `?` button
- [x] Navigating, zooming, and deleting a tree are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)