### PR TITLE
Simplify conditional help button append in createModal

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -84,7 +84,8 @@ function createModal({title, onClose, getHelpSample}) {
   closeButton.textContent = "×";
   closeButton.addEventListener("click", onClose);
 
-  headerActions.append(...(helpButton ? [helpButton] : []), closeButton);
+  if (helpButton) headerActions.append(helpButton);
+  headerActions.append(closeButton);
   header.append(heading, headerActions);
   dialog.appendChild(header);
   group.appendChild(dialog);


### PR DESCRIPTION
## Summary

- Replaces the spread-array workaround `headerActions.append(...(helpButton ? [helpButton] : []), closeButton)` with a plain conditional append, which is easier to read and doesn't require constructing a temporary array.
- No behavior change — only the `?` help button is conditionally inserted; the close button is always present.

## Review notes

A full correctness review of the PR #40 changes was run before this PR was opened. Two candidates were investigated and refuted:
- **querySelector injection via `added.id`**: IDs are Supabase UUIDs (hex + hyphens only), safe for CSS attribute selectors.
- **D3 `.attr(name, null)` producing the string `"null"`**: D3 v7 removes the attribute when given `null`; archive trees (no `dbId`) simply won't have a `data-db-id` attribute.

## Test plan

- [x] Open any modal with help content (plant, my trees) — `?` button still appears and toggles the help panel
- [x] Open the search modal (dev mode) — no `?` button, just the close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)